### PR TITLE
feat: remove launchDir from output path

### DIFF
--- a/conf/pixelgen.config
+++ b/conf/pixelgen.config
@@ -2,11 +2,8 @@ import nextflow.Nextflow
 
 def pixelgenOutputDir(workflow, params) {
     // Function used to generate the an output path on the form:
-    // <flowcell identifer>/<nf-core-pixelator version>-<pixelator version>/<date>-<sha>/
+    // <nf-core-pixelator version>-<pixelator version>/<date>-<sha>/
 
-    // TODO Do we want to assume that the dir one start the pipeline in is the
-    // flowcell?
-    flowcellName = launchDir.getFileName()
     pipelineVersion = workflow.manifest.version
     pixelatorVersion = params.pixelator_tag ?: "unknown"
     today = new Date().format("yyyy-MM-dd")
@@ -16,7 +13,7 @@ def pixelgenOutputDir(workflow, params) {
     parameterSha = params.sort().toString().digest('sha-1')
     combinedSha = "${samplesheetSha}${parameterSha}".digest("sha-1").substring(0, 6)
 
-    return "${flowcellName}/${pipelineVersion}/${pixelatorVersion}/${today}/${combinedSha}"
+    return "${pipelineVersion}/${pixelatorVersion}/${today}/${combinedSha}"
 }
 
 process {

--- a/lib/WorkflowMain.groovy
+++ b/lib/WorkflowMain.groovy
@@ -102,14 +102,11 @@ class WorkflowMain {
 
     private static String pixelgenOutputDir(workflow, params) {
         // Function used to generate the an output path on the form:
-        // <flowcell identifer>/<nf-core-pixelator version>-<pixelator version>/<date>-<sha>/
+        // /<nf-core-pixelator version>-<pixelator version>/<date>-<sha>/
 
         // TODO This duplicates the function in `pixelgen.config`. It's ugly, but I've
         // not figured out any better way to do this so far.
 
-        // TODO Do we want to assume that the dir one start the pipeline in is the
-        // flowcell?
-        def flowcellName = workflow.launchDir.getFileName()
         def pipelineVersion = workflow.manifest.version
         def pixelatorVersion = params.pixelator_tag ?: "unknown"
         def today = new Date().format("yyyy-MM-dd")
@@ -119,7 +116,7 @@ class WorkflowMain {
         def parameterSha = params.sort().toString().digest('sha-1')
         def combinedSha = "${samplesheetSha}${parameterSha}".digest("sha-1").substring(0, 6)
 
-        return "${flowcellName}/${pipelineVersion}/${pixelatorVersion}/${today}/${combinedSha}"
+        return "${pipelineVersion}/${pixelatorVersion}/${today}/${combinedSha}"
     }
 
     public static void writeMetadata(workflow, params) {


### PR DESCRIPTION
## PR checklist

Remove the `launchDir` from the output path. The user will instead use `outdir` to create the first part. Me and @fbdtemme agreed that makes more sense.

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
