### PR TITLE
fix: invalid file scheme for local paths

### DIFF
--- a/bin/check_samplesheet.py
+++ b/bin/check_samplesheet.py
@@ -28,7 +28,7 @@ def make_absolute_path(path: str, base: PathLike = None) -> str:
     # If the base url has a scheme we need to keep that
     # purepath will remove double slashes and this invalidates the base scheme
     base_url = urllib.parse.urlparse(str(base))
-    base_scheme = base_url.scheme or "file"
+    base_scheme = f"{base_url.scheme}://" or "file:///"
     # Url path contains root slash.
     # We will add this while adding the scheme so strip it here
     base_path = base_url.path.lstrip("/")
@@ -36,7 +36,7 @@ def make_absolute_path(path: str, base: PathLike = None) -> str:
     in_path = PurePath(path)
     if not in_path.is_absolute() and base is not None:
         resolved_path = PurePath(base_path) / in_path
-        return f"{base_scheme}://{str(resolved_path)}"
+        return f"{base_scheme}{str(resolved_path)}"
 
     return str(in_path)
 


### PR DESCRIPTION
Fix an issue where relative paths resolved from the samplesheet from the local filesystem would have an invalid uri.
The resolved links would be eg: `file://path/to/file.csv` but uri's with the file scheme need triple slashes `file:///` while remote storage uri's only need two eg. `s3://`

FIY:

Apparently the the file uri is actually `file://host/path` were host is `localhost`. The localhost can be ommited so it becomes `file:///path`

See [RFC 1738 – Uniform Resource Locators (URL)](http://www.ietf.org/rfc/rfc1738.txt):
