### PR TITLE
refactor: split out pixelator dependency in CHECK_SAMPLESHEET

### DIFF
--- a/bin/check_samplesheet.py
+++ b/bin/check_samplesheet.py
@@ -8,13 +8,12 @@ import abc
 import argparse
 import csv
 import logging
+import re
 import sys
 import urllib.parse
-from collections import Counter
-from pathlib import Path, PurePath
-import re
-from typing import Iterable, List, MutableMapping, Optional, Set
 from os import PathLike
+from pathlib import Path, PurePath
+from typing import Iterable, List, MutableMapping, Optional, Set
 
 logger = logging.getLogger()
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -19,12 +19,6 @@ process {
         saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
     ]
 
-    withName: 'SAMPLESHEET_CHECK' {
-        if (params.pixelator_container) {
-            container = params.pixelator_container
-        }
-    }
-
     withName: COLLECT_METADATA {
         publishDir = [
             path: { "${params.outdir}/pipeline_info" },

--- a/modules/local/pixelator/list_designs.nf
+++ b/modules/local/pixelator/list_designs.nf
@@ -1,0 +1,26 @@
+process PIXELATOR_LIST_DESIGNS {
+    label 'process_single'
+
+    // TODO: Update once pixelator is public in bioconda
+    conda "local::pixelator=0.12.0"
+    container "ghcr.io/pixelgentechnologies/pixelator:0.12.0"
+
+    output:
+    path "design_options.txt"     , emit: designs
+    path "versions.yml"           , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+
+    """
+    pixelator single-cell --list-designs $args > design_options.txt
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        pixelator: \$(echo \$(pixelator --version 2>/dev/null) | sed 's/pixelator, version //g' )
+    END_VERSIONS
+    """
+}

--- a/subworkflows/local/input_check.nf
+++ b/subworkflows/local/input_check.nf
@@ -2,15 +2,24 @@
 // Check input samplesheet and get read channels
 //
 
-include { SAMPLESHEET_CHECK } from '../../modules/local/samplesheet_check'
+include { SAMPLESHEET_CHECK }        from '../../modules/local/samplesheet_check'
+include { PIXELATOR_LIST_DESIGNS }   from '../../modules/local/pixelator/list_designs.nf'
 
 workflow INPUT_CHECK {
     take:
     samplesheet                                // file: /path/to/samplesheet.csv
 
     main:
-    ch_samplesheet_rows = SAMPLESHEET_CHECK ( samplesheet, samplesheet.toUri() )
-        .csv
+
+    PIXELATOR_LIST_DESIGNS()
+
+    SAMPLESHEET_CHECK (
+        samplesheet,
+        PIXELATOR_LIST_DESIGNS.out.designs,
+        samplesheet.toUri()
+    )
+
+    ch_samplesheet_rows = SAMPLESHEET_CHECK.out.csv
         .splitCsv ( header:true, sep:',' )
 
     reads = ch_samplesheet_rows.map { create_fastq_channel(it) }


### PR DESCRIPTION
As discussed here: https://github.com/PixelgenTechnologies/nf-core-pixelator/pull/57#discussion_r1288515954

Split out `pixelator` use from CHECK_SAMPLESHEET.
The possible design options are now an extra file input to CHECK_SAMPLESHEET.