### PR TITLE
Fix absolute and remote paths in samplesheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.2dev] - UNRELEASED
 
+### Enhancements & fixes
+
+- [[PR #70](https://github.com/nf-core/pixelator/pull/70)] - Fix loading of absolute paths and urls in input samplesheet
+
 ## [1.0.1] - 2023-10-27
 
 ### Enhancements & fixes

--- a/samplesheet.csv
+++ b/samplesheet.csv
@@ -1,3 +1,3 @@
 sample,design,panel,fastq_1,fastq_2
-uropod_control,D21,human-sc-immunology-spatial-proteomics,uropod_control_300k_R1_001.fastq.gz,uropod_control_300k_R2_001.fastq.gz
+uropod_control,D21,human-sc-immunology-spatial-proteomics,/home/fbdtemme/Documents/pixelgen/nf-core-pixelator-datasets/testdata/micro/uropod_control_300k_S1_R1_001.fastq.gz,/home/fbdtemme/Documents/pixelgen/nf-core-pixelator-datasets/testdata/micro/uropod_control_300k_S1_R2_001.fastq.gz
 pbmcs_unstimulated,D21,human-sc-immunology-spatial-proteomics,Sample01_human_pbmcs_unstimulated_200k_R1_001.fastq.gz,Sample01_human_pbmcs_unstimulated_200k_R2_001.fastq.gz

--- a/samplesheet.csv
+++ b/samplesheet.csv
@@ -1,3 +1,0 @@
-sample,design,panel,fastq_1,fastq_2
-uropod_control,D21,human-sc-immunology-spatial-proteomics,/home/fbdtemme/Documents/pixelgen/nf-core-pixelator-datasets/testdata/micro/uropod_control_300k_S1_R1_001.fastq.gz,/home/fbdtemme/Documents/pixelgen/nf-core-pixelator-datasets/testdata/micro/uropod_control_300k_S1_R2_001.fastq.gz
-pbmcs_unstimulated,D21,human-sc-immunology-spatial-proteomics,Sample01_human_pbmcs_unstimulated_200k_R1_001.fastq.gz,Sample01_human_pbmcs_unstimulated_200k_R2_001.fastq.gz

--- a/subworkflows/local/input_check.nf
+++ b/subworkflows/local/input_check.nf
@@ -79,12 +79,12 @@ def resolve_relative_path(relative_path, URI samplesheet_path) {
 
     // If a scheme is given we keep it as given
     if (uri.getScheme() != null) {
-        return uri
+        return relative_path
     }
 
-    def path = new File(relative_path);
+    def path = new File(relative_path)
     if (path.isAbsolute()) {
-        return path
+        return relative_path
     }
 
     // Resolve relative paths agains the samplesheet_path


### PR DESCRIPTION
Fix an issue with loading absolute paths and remote resource urls from the samplesheet.

This was caused by a wrong return value in the samplesheet loading in `resolve_relative_path` . 
Downstring code expects strings but a groovy file object was returned when the path is already absolute.