### PR TITLE
Prepping for pixelator 1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [UNRELEASED] - YYYY-MM-DD
+
+### Changed
+
+- `collapse` and `graph` steps output parquet files
+
 ## [[1.0.3](https://github.com/nf-core/pixelator/releases/tag/1.0.3)] - 2024-01-19
 
 ### Enhancements & fixes

--- a/custom.config
+++ b/custom.config
@@ -1,0 +1,5 @@
+
+// Change which pixelator backend is used.
+env {
+    PIXELATOR_GRAPH_BACKEND = "NetworkXGraphBackend"
+}

--- a/custom.config
+++ b/custom.config
@@ -1,5 +1,0 @@
-
-// Change which pixelator backend is used.
-env {
-    PIXELATOR_GRAPH_BACKEND = "NetworkXGraphBackend"
-}

--- a/docs/output.md
+++ b/docs/output.md
@@ -110,7 +110,7 @@ given barcodes/antibodies.
 
   - `collapse`
 
-    - `<sample-id>.collapsed.csv.gz`: Edgelist of the graph.
+    - `<sample-id>.collapsed.parquet`: Edgelist of the graph.
     - `<sample-id>.report.json`: Statistics for the collapse step.
     - `<sample-id>.meta.json`: Command invocation metadata.
 
@@ -137,10 +137,8 @@ The output format of this command is an edge list in CSV format.
 
   - `graph`
 
-    - `<sample-id>.edgelist.csv.gz`:
-      Edge list dataframe (CSV) after recovering technical multiplets.
-    - `<sample-id>.raw_edgelist.csv.gz`:
-      Raw edge list dataframe in csv format before recovering technical multiplets.
+    - `<sample-id>.edgelist.parquet`:
+      Edge list dataframe after recovering technical multiplets.
     - `<sample-id>.components_recovered.csv`:
       List of new components recovered (when using `--multiple-recovery`)
     - `<sample-id>.meta.json`: Command invocation metadata.

--- a/modules/local/pixelator/single-cell/collapse/main.nf
+++ b/modules/local/pixelator/single-cell/collapse/main.nf
@@ -11,12 +11,12 @@ process PIXELATOR_COLLAPSE {
     tuple val(meta), path(reads), path(panel_file), val(panel)
 
     output:
-    tuple val(meta), path("collapse/*.collapsed.csv.gz"), emit: collapsed
-    tuple val(meta), path("collapse/*.report.json")     , emit: report_json
-    tuple val(meta), path("collapse/*.meta.json")       , emit: metadata
-    tuple val(meta), path("*pixelator-collapse.log")    , emit: log
+    tuple val(meta), path("collapse/*.collapsed.parquet"), emit: collapsed
+    tuple val(meta), path("collapse/*.report.json")      , emit: report_json
+    tuple val(meta), path("collapse/*.meta.json")        , emit: metadata
+    tuple val(meta), path("*pixelator-collapse.log")     , emit: log
 
-    path "versions.yml"                                 , emit: versions
+    path "versions.yml"                                  , emit: versions
 
     when:
     task.ext.when == null || task.ext.when

--- a/modules/local/pixelator/single-cell/graph/main.nf
+++ b/modules/local/pixelator/single-cell/graph/main.nf
@@ -12,8 +12,7 @@ process PIXELATOR_GRAPH {
     tuple val(meta), path(edge_list)
 
     output:
-    tuple val(meta), path("graph/*.edgelist.csv.gz")         , emit: edgelist
-    tuple val(meta), path("graph/*.raw_edgelist.csv.gz")     , emit: raw_edgelist
+    tuple val(meta), path("graph/*.edgelist.parquet")         , emit: edgelist
     tuple val(meta), path("graph/*.components_recovered.csv"), emit: components_recovered, optional: true
     tuple val(meta), path("graph/*.report.json")             , emit: report_json
     tuple val(meta), path("graph/*.meta.json")               , emit: input_params

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -10,7 +10,10 @@
             "type": "object",
             "fa_icon": "fas fa-terminal",
             "description": "Define where the pipeline should find input data and save output data.",
-            "required": ["input", "outdir"],
+            "required": [
+                "input",
+                "outdir"
+            ],
             "properties": {
                 "input": {
                     "type": "string",
@@ -147,7 +150,10 @@
                     "fa_icon": "fas code-fork",
                     "description": "The algorithm to use for collapsing (adjacency will perform error correction using the number of mismatches given)",
                     "default": "adjacency",
-                    "enum": ["adjacency", "unique"],
+                    "enum": [
+                        "adjacency",
+                        "unique"
+                    ],
                     "type": "string"
                 },
                 "max_neighbours": {
@@ -224,7 +230,11 @@
                 "dynamic_filter": {
                     "description": " Enable the estimation of dynamic size filters using a log-rank approach both: estimate both min and max size, min: estimate min size (--min-size), max: estimate max size (--max-size)",
                     "type": "string",
-                    "enum": ["both", "min", "max"],
+                    "enum": [
+                        "both",
+                        "min",
+                        "max"
+                    ],
                     "default": "min"
                 },
                 "aggregate_calling": {
@@ -260,7 +270,11 @@
                     "description": "Which approach to use to normalize the antibody counts.",
                     "help_text": "- `raw`: use the raw counts.\n- `CLR`: use the CLR-transformed counts.\n- `denoise`: use CLR-transformed counts and subtract the counts of control antibodies",
                     "type": "string",
-                    "enum": ["raw", "clr", "denoise"],
+                    "enum": [
+                        "raw",
+                        "clr",
+                        "denoise"
+                    ],
                     "default": "clr"
                 },
                 "polarization_binarization": {
@@ -270,7 +284,12 @@
                 },
                 "colocalization_transformation": {
                     "type": "string",
-                    "enum": ["raw", "clr", "log1p", "relative"],
+                    "enum": [
+                        "raw",
+                        "clr",
+                        "log1p",
+                        "relative"
+                    ],
                     "default": "log1p",
                     "description": "Select the type of transformation to use on the node by antibody counts matrix when computing colocalization"
                 },
@@ -424,7 +443,14 @@
                     "description": "Method used to save pipeline results to output directory.",
                     "help_text": "The Nextflow `publishDir` option specifies which intermediate files should be saved to the output directory. This option tells the pipeline what method should be used to move these files. See [Nextflow docs](https://www.nextflow.io/docs/latest/process.html#publishdir) for details.",
                     "fa_icon": "fas fa-copy",
-                    "enum": ["symlink", "rellink", "link", "copy", "copyNoFollow", "move"],
+                    "enum": [
+                        "symlink",
+                        "rellink",
+                        "link",
+                        "copy",
+                        "copyNoFollow",
+                        "move"
+                    ],
                     "hidden": true
                 },
                 "email_on_fail": {


### PR DESCRIPTION
This PR contains changes that prepare nf-core/pixelator for the 1.0 release of pixelator. The main difference is that the `collapse` and `graph` steps will now output parquet files. It also fixes a bunch of spelling errors.

For now, since the new pixelator version is not release in order for the tests to pass you need to add: `--pixelator_container ghcr.io/pixelgentechnologies/pixelator:dev`. We should update the default container once everything is in place in biocontainers.

Linting currently fails, which I guess is because we have note yet updated to the new nf-core templates?

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
