### PR TITLE
fix: use adapterqc output  as main output of PIXELATOR_QC

### DIFF
--- a/.nf-core.yml
+++ b/.nf-core.yml
@@ -7,3 +7,4 @@ lint:
     - conf/igenomes.config
   files_unchanged:
     - lib/NfcoreTemplate.groovy
+    - .prettierignore

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,7 @@
 email_template.html
 adaptivecard.json
 slackreport.json
+.devcontainer/devcontainer.json
 .nextflow*
 work/
 data/

--- a/modules/local/pixelator/single-cell/qc/main.nf
+++ b/modules/local/pixelator/single-cell/qc/main.nf
@@ -12,7 +12,7 @@ process PIXELATOR_QC {
     tuple val(meta), path(reads)
 
     output:
-    tuple val(meta), path("preqc/*.processed.{fq,fastq}.gz")         , emit: processed
+    tuple val(meta), path("adapterqc/*.processed.{fq,fastq}.gz")     , emit: processed
 
     tuple val(meta), path("adapterqc/*.processed.{fq,fastq}.gz")     , emit: adapterqc_processed
     tuple val(meta), path("preqc/*.processed.{fq,fastq}.gz")         , emit: preqc_processed


### PR DESCRIPTION
Change the main output of PIXELATOR_QC to `pixelator single-cell adapterqc` output.
It was incorrectly set to use  `pixelator single-cell preqc`  output.