### PR TITLE
Make `task.ext` assigments closures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,11 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [[UNRELEASED](https://github.com/nf-core/pixelator/releases/tag/?.?.?)] - 2024-??-??
+## [[1.3.0dev](https://github.com/nf-core/pixelator/releases/tag/?.?.?)] - 2024-??-??
 
 ### Enhancements & fixes
+
+- [[PR #96](https://github.com/nf-core/pixelator/pull/96)] - Make all ext.args assignments closures
 
 ### Software dependencies
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -93,55 +93,65 @@ process {
     }
 
     withName: PIXELATOR_COLLAPSE {
-        ext.args = [
-            params.markers_ignore ? "--markers_ignore ${params.markers_ignore}":
-            params.algorithm ? "--algorithm ${params.algorithm}": '',
-            params.max_neighbours ? "--max-neighbours ${params.max_neighbours}": '',
-            params.collapse_mismatches ? "--mismatches ${params.collapse_mismatches}": '',
-            params.collapse_min_count ? "--min-count ${params.collapse_min_count}": '',
-            params.collapse_use_counts ? "--use-counts": '',
-        ].join(' ').trim()
+        ext.args = {
+            [
+                params.markers_ignore ? "--markers_ignore ${params.markers_ignore}":
+                params.algorithm ? "--algorithm ${params.algorithm}": '',
+                params.max_neighbours ? "--max-neighbours ${params.max_neighbours}": '',
+                params.collapse_mismatches ? "--mismatches ${params.collapse_mismatches}": '',
+                params.collapse_min_count ? "--min-count ${params.collapse_min_count}": '',
+                params.collapse_use_counts ? "--use-counts": '',
+            ].join(' ').trim()
+        }
     }
 
     withName: PIXELATOR_GRAPH {
-        ext.args = [
-            params.multiplet_recovery ? "--multiplet-recovery" : '',
-            params.leiden_iterations ? "--leiden-iterations ${params.leiden_iterations}" : '',
-            params.graph_min_count ? "--min-count ${params.graph_min_count}" : '',
-        ].join(' ').trim()
+        ext.args = {
+            [
+                params.multiplet_recovery ? "--multiplet-recovery" : '',
+                params.leiden_iterations ? "--leiden-iterations ${params.leiden_iterations}" : '',
+                params.graph_min_count ? "--min-count ${params.graph_min_count}" : '',
+            ].join(' ').trim()
+        }
     }
 
     withName: PIXELATOR_ANNOTATE {
-        ext.args = [
-            (params.min_size instanceof Integer) ? "--min-size ${params.min_size}" : '',
-            (params.max_size instanceof Integer) ? "--max-size ${params.max_size}" : '',
-            params.dynamic_filter ? "--dynamic-filter ${params.dynamic_filter}" : '',
-            params.aggregate_calling ? "--aggregate-calling" : '',
-        ].join(' ').trim()
+        ext.args = {
+            [
+                (params.min_size instanceof Integer) ? "--min-size ${params.min_size}" : '',
+                (params.max_size instanceof Integer) ? "--max-size ${params.max_size}" : '',
+                params.dynamic_filter ? "--dynamic-filter ${params.dynamic_filter}" : '',
+                params.aggregate_calling ? "--aggregate-calling" : '',
+            ].join(' ').trim()
+        }
     }
 
     withName: PIXELATOR_ANALYSIS {
         ext.when = { !params.skip_analysis }
-        ext.args = [
-            params.compute_polarization ? "--compute-polarization" : '',
-            params.compute_colocalization ? "--compute-colocalization" : '',
-            params.use_full_bipartite ? "--use-full-bipartite " : '',
-            params.polarization_min_marker_count ? "--polarization-min-marker-count ${params.polarization_min_marker_count}" : '',
-            params.polarization_transformation ? "--polarization-transformation ${params.polarization_transformation}" : '',
-            params.colocalization_transformation ? "--colocalization-transformation ${params.colocalization_transformation}" : '',
-            params.polarization_n_permutations ? "--polarization-n-permutations ${params.polarization_n_permutations}" : '',
-            (params.colocalization_neighbourhood_size instanceof Integer) ? "--colocalization-neighbourhood-size ${params.colocalization_neighbourhood_size}" : '',
-            (params.colocalization_n_permutations instanceof Integer) ? "--colocalization-n-permutations ${params.colocalization_n_permutations}" : '',
-            (params.colocalization_min_region_count instanceof Integer) ? "--colocalization-min-region-count ${params.colocalization_min_region_count}" : '',
-        ].join(' ').trim()
+        ext.args = {
+            [
+                params.compute_polarization ? "--compute-polarization" : '',
+                params.compute_colocalization ? "--compute-colocalization" : '',
+                params.use_full_bipartite ? "--use-full-bipartite " : '',
+                params.polarization_min_marker_count ? "--polarization-min-marker-count ${params.polarization_min_marker_count}" : '',
+                params.polarization_transformation ? "--polarization-transformation ${params.polarization_transformation}" : '',
+                params.colocalization_transformation ? "--colocalization-transformation ${params.colocalization_transformation}" : '',
+                params.polarization_n_permutations ? "--polarization-n-permutations ${params.polarization_n_permutations}" : '',
+                (params.colocalization_neighbourhood_size instanceof Integer) ? "--colocalization-neighbourhood-size ${params.colocalization_neighbourhood_size}" : '',
+                (params.colocalization_n_permutations instanceof Integer) ? "--colocalization-n-permutations ${params.colocalization_n_permutations}" : '',
+                (params.colocalization_min_region_count instanceof Integer) ? "--colocalization-min-region-count ${params.colocalization_min_region_count}" : '',
+            ].join(' ').trim()
+        }
     }
 
     withName: PIXELATOR_LAYOUT {
         ext.when = { !params.skip_layout }
-        ext.args = [
-            params.no_node_marker_counts ? "--no-node-marker-counts" : '',
-            params.layout_algorithm ? "--layout-algorithm ${params.layout_algorithm} " : '',
-        ].join(' ').trim()
+        ext.args = {
+            [
+                params.no_node_marker_counts ? "--no-node-marker-counts" : '',
+                params.layout_algorithm ? "--layout-algorithm ${params.layout_algorithm} " : '',
+            ].join(' ').trim()
+        }
     }
 
     withName: PIXELATOR_REPORT {


### PR DESCRIPTION
# Description

Make all `task.ext` assigments closures. 
When people pass `params` in seperate config files the results can be very unintuitive and depends on the order of config file evaluation. Delaying the creation of additional commandline options with closures works around this.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/pixelator/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/pixelator _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
