### PR TITLE
Use R1/R2 suffixes in amplicon input fastq file renaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [[PR #96](https://github.com/nf-core/pixelator/pull/96)] - Make all ext.args assignments closures
 - [[PR #98](https://github.com/nf-core/pixelator/pull/98)] - Update metromap to include layout step
 - [[PR #99](https://github.com/nf-core/pixelator/pull/99)] - Update README to include layout step
+- [[PR #100](https://github.com/nf-core/pixelator/pull/100)] - Use R1/R2 suffixes in amplicon input fastq file renaming
 
 ### Software dependencies
 

--- a/modules/local/pixelator/single-cell/amplicon/main.nf
+++ b/modules/local/pixelator/single-cell/amplicon/main.nf
@@ -26,10 +26,11 @@ process PIXELATOR_AMPLICON {
     def prefix = task.ext.prefix ?: "${meta.id}"
     def args = task.ext.args ?: ''
 
-    // Make list of old name and new name pairs to use for renaming in the bash while loop
+    // Make list of old name and new name pairs to use for renaming
+    // Use R1/R2 style suffixes for limited backward compatibility with pixelator<0.17
     def old_new_pairs = (reads instanceof Path || reads.size() == 1)
         ? [[ reads, "${prefix}${getFileSuffix(reads)}" ]]
-        : reads.withIndex().collect { entry, index -> [ entry, "${prefix}_${index + 1}${getFileSuffix(entry)}" ] }
+        : reads.withIndex().collect { entry, index -> [ entry, "${prefix}_R${index + 1}${getFileSuffix(entry)}" ] }
 
     def rename_to = old_new_pairs*.join(' ').join(' ')
     def renamed_reads = old_new_pairs.collect { old_name, new_name -> new_name }.join(' ')


### PR DESCRIPTION
## Description

Use _R1/_R2 suffixes in amplicon input fastq file renaming instead of _1/_2
This ensures limited backward compatibility when using the pipeline with older pixelator containers (<0.17) using the `--pixelator_container` flag.
