### PR TITLE
Fix validation issue when using panel_file instead of panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [[PR #98](https://github.com/nf-core/pixelator/pull/98)] - Update metromap to include layout step
 - [[PR #99](https://github.com/nf-core/pixelator/pull/99)] - Update README to include layout step
 - [[PR #100](https://github.com/nf-core/pixelator/pull/100)] - Use R1/R2 suffixes in amplicon input fastq file renaming
+- [[PR #101](https://github.com/nf-core/pixelator/pull/101)] - Fix validation issue when using panel_file instead of panel
 
 ### Software dependencies
 

--- a/subworkflows/local/utils_nfcore_pixelator_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_pixelator_pipeline/main.nf
@@ -339,7 +339,7 @@ def resolve_relative_path(relative_path, URI samplesheet_path) {
 //
 def validate_panel(LinkedHashMap meta, HashSet options) {
     if (meta.panel == null) {
-        return
+        return meta
     }
 
     if (!options.contains(meta.panel)) {
@@ -356,7 +356,7 @@ def validate_panel(LinkedHashMap meta, HashSet options) {
 //
 def validate_design(LinkedHashMap meta, HashSet options) {
     if (meta.design == null) {
-        return
+        return meta
     }
 
     if (!options.contains(meta.design)) {


### PR DESCRIPTION
A map access error occurs because the meta map gets overwritten with null in validate_panel when no panel key is present. We need to return the meta map unmodified instead.