### PR TITLE
Restructure output folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [[PR #99](https://github.com/nf-core/pixelator/pull/99)] - Update README to include layout step
 - [[PR #100](https://github.com/nf-core/pixelator/pull/100)] - Use R1/R2 suffixes in amplicon input fastq file renaming
 - [[PR #101](https://github.com/nf-core/pixelator/pull/101)] - Fix validation issue when using panel_file instead of panel
+- [[PR #102](https://github.com/nf-core/pixelator/pull/101)] - Restructure output directory
 
 ### Software dependencies
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -324,6 +324,7 @@ process {
                     else if (params.save_analysis_dataset || params.save_all) {
                         return it
                     }
+                    return null
                 }
             ],
             [

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -231,7 +231,7 @@ process {
             [
                 path: { "${params.outdir}/pixelator" },
                 mode: params.publish_dir_mode,
-                pattern: 'graph/*.components_recovered.csv',
+                pattern: 'graph/*edgelist.parquet',
                 saveAs: { (params.save_edgelist || params.save_all) ? it : null }
             ],
             [

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -14,7 +14,7 @@
 process {
 
     publishDir = [
-        path: { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" },
+        path: { "${params.outdir}/pixelator" },
         mode: params.publish_dir_mode,
         saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
     ]
@@ -22,14 +22,14 @@ process {
     withName: "PIXELATOR.*" {
         publishDir = [
             [
-                path: { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" },
+                path: { "${params.outdir}/pixelator" },
                 mode: params.publish_dir_mode,
                 saveAs: { filename -> (filename.endsWith('.log') || filename.equals('versions.yml')) ? null : filename }
             ],
             [
-                path: { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}/logs" },
+                path: { "${params.outdir}/pixelator/logs" },
                 mode: params.publish_dir_mode,
-                pattern: "*.log"
+                pattern: '*.log'
             ]
         ]
 
@@ -47,15 +47,50 @@ process {
     }
 
 
+    withName: PIXELATOR_COLLECT_METADATA {
+        publishDir = [
+            [
+                path: { "${params.outdir}/pipeline_info" },
+                mode: params.publish_dir_mode,
+                pattern: 'metadata.json',
+                saveAs: { filename ->
+                    def timestamp  = new java.util.Date().format( 'yyyy-MM-dd_HH-mm-ss')
+                    "metadata_${timestamp}.json"
+                }
+            ],
+            [
+                path: { "${params.outdir}/pixelator/logs" },
+                mode: params.publish_dir_mode,
+                pattern: '*.log'
+            ]
+        ]
+    }
+
     // use explicit (params.my_option instanceof Integer) checks to avoid issues with 0 evaluating false
     // since most pixelator flags do accept zero as a value
 
     withName: PIXELATOR_AMPLICON {
-        ext.args = {
+        ext.args = { ["--design ${meta.design}"].join(' ').trim() }
+
+        publishDir = [
             [
-                "--design ${meta.design}",
-            ].join(' ').trim()
-        }
+                path: { "${params.outdir}/pixelator" },
+                mode: params.publish_dir_mode,
+                pattern: 'amplicon/*.merged.{fq,fastq}.gz',
+                saveAs: { (params.save_amplicon_reads || params.save_all) ? it : null }
+            ],
+            [
+                path: { "${params.outdir}/pixelator/logs/${meta.id}" },
+                mode: params.publish_dir_mode,
+                pattern: "*.log"
+            ],
+            [
+                path: { "${params.outdir}/pixelator" },
+                mode: params.publish_dir_mode,
+                pattern: '**/*.{report,meta}.json',
+                saveAs: { params.save_all ? it : null }
+            ]
+        ]
     }
 
     withName: PIXELATOR_QC {
@@ -80,6 +115,32 @@ process {
                 params.adapterqc_mismatches ? "--mismatches ${params.adapterqc_mismatches}": '',
             ].join(' ').trim()
         }
+
+        publishDir = [
+            [
+                path: { "${params.outdir}/pixelator" },
+                mode: params.publish_dir_mode,
+                pattern: '{preqc,adapterqc}/*.processed.{fq,fastq}.gz',
+                saveAs: { (params.save_qc_passed_reads || params.save_all) ? it : null }
+            ],
+            [
+                path: { "${params.outdir}/pixelator" },
+                mode: params.publish_dir_mode,
+                pattern: '{preqc,adapterqc}/*.failed.{fq,fastq}.gz',
+                saveAs: { (params.save_qc_failed_reads || params.save_all) ? it : null }
+            ],
+            [
+                path: { "${params.outdir}/pixelator/logs/${meta.id}" },
+                mode: params.publish_dir_mode,
+                pattern: '*.log'
+            ],
+            [
+                path: { "${params.outdir}/pixelator" },
+                mode: params.publish_dir_mode,
+                pattern: '**/*.{report,meta}.json',
+                saveAs: { (params.save_all) ? it : null }
+            ]
+        ]
     }
 
     withName: PIXELATOR_DEMUX {
@@ -90,6 +151,32 @@ process {
                 (params.demux_min_length instanceof Integer) ? "--mismatches ${params.demux_min_length}": '',
             ].join(' ').trim()
         }
+
+        publishDir = [
+            [
+                path: { "${params.outdir}/pixelator" },
+                mode: params.publish_dir_mode,
+                pattern: 'demux/*.processed-*.{fq,fastq}.gz',
+                saveAs: { (params.save_demux_processed_reads || params.save_all) ? it : null }
+            ],
+            [
+                path: { "${params.outdir}/pixelator" },
+                mode: params.publish_dir_mode,
+                pattern: 'demux/*failed.{fq,fastq}.gz',
+                saveAs: { (params.save_demux_failed_reads || params.save_all) ? it : null }
+            ],
+            [
+                path: { "${params.outdir}/pixelator/logs/${meta.id}" },
+                mode: params.publish_dir_mode,
+                pattern: '*.log'
+            ],
+            [
+                path: { "${params.outdir}/pixelator" },
+                mode: params.publish_dir_mode,
+                pattern: '**/*.{report,meta}.json',
+                saveAs: { (params.save_all) ? it : null }
+            ]
+        ]
     }
 
     withName: PIXELATOR_COLLAPSE {
@@ -103,6 +190,26 @@ process {
                 params.collapse_use_counts ? "--use-counts": '',
             ].join(' ').trim()
         }
+
+        publishDir = [
+            [
+                path: { "${params.outdir}/pixelator" },
+                mode: params.publish_dir_mode,
+                pattern: 'collapse/*.collapsed.parquet',
+                saveAs: { (params.save_collapsed_reads || params.save_all) ? it : null }
+            ],
+            [
+                path: { "${params.outdir}/pixelator/logs/${meta.id}" },
+                mode: params.publish_dir_mode,
+                pattern: '*.log'
+            ],
+            [
+                path: { "${params.outdir}/pixelator" },
+                mode: params.publish_dir_mode,
+                pattern: '**/*.{report,meta}.json',
+                saveAs: { (params.save_all) ? it : null }
+            ]
+        ]
     }
 
     withName: PIXELATOR_GRAPH {
@@ -113,6 +220,32 @@ process {
                 params.graph_min_count ? "--min-count ${params.graph_min_count}" : '',
             ].join(' ').trim()
         }
+
+        publishDir = [
+            [
+                path: { "${params.outdir}/pixelator" },
+                mode: params.publish_dir_mode,
+                pattern: 'graph/*.components_recovered.csv',
+                saveAs: { (params.save_recovered_components || params.save_all) ? it : null }
+            ],
+            [
+                path: { "${params.outdir}/pixelator" },
+                mode: params.publish_dir_mode,
+                pattern: 'graph/*.components_recovered.csv',
+                saveAs: { (params.save_edgelist || params.save_all) ? it : null }
+            ],
+            [
+                path: { "${params.outdir}/pixelator/logs/${meta.id}" },
+                mode: params.publish_dir_mode,
+                pattern: '*.log'
+            ],
+            [
+                path: { "${params.outdir}/pixelator" },
+                mode: params.publish_dir_mode,
+                pattern: '**/*.{report,meta}.json',
+                saveAs: { (params.save_all) ? it : null }
+            ]
+        ]
     }
 
     withName: PIXELATOR_ANNOTATE {
@@ -124,6 +257,41 @@ process {
                 params.aggregate_calling ? "--aggregate-calling" : '',
             ].join(' ').trim()
         }
+
+        publishDir = [
+            [
+                path: { "${params.outdir}/pixelator" },
+                mode: params.publish_dir_mode,
+                pattern: 'annotate/*.dataset.pxl',
+                saveAs: {
+                    if (params.skip_layout && params.skip_analysis) {
+                        // Trim the annotate directory prefix from the output name
+                        return new File(it).name
+                    }
+                    else if (params.save_annotate_dataset || params.save_all) {
+                        return it
+                    }
+                    return null
+                }
+            ],
+            [
+                path: { "${params.outdir}/pixelator" },
+                mode: params.publish_dir_mode,
+                pattern: '**/*.{report,meta}.json',
+                saveAs: { (params.save_raw_component_metrics || params.save_all) ? it : null }
+            ],
+            [
+                path: { "${params.outdir}/pixelator/logs/${meta.id}" },
+                mode: params.publish_dir_mode,
+                pattern: '*.log'
+            ],
+            [
+                path: { "${params.outdir}/pixelator" },
+                mode: params.publish_dir_mode,
+                pattern: '**/*.{report,meta}.json',
+                saveAs: { (params.save_all) ? it : null }
+            ]
+        ]
     }
 
     withName: PIXELATOR_ANALYSIS {
@@ -142,6 +310,34 @@ process {
                 (params.colocalization_min_region_count instanceof Integer) ? "--colocalization-min-region-count ${params.colocalization_min_region_count}" : '',
             ].join(' ').trim()
         }
+
+        publishDir = [
+            [
+                path: { "${params.outdir}/pixelator" },
+                mode: params.publish_dir_mode,
+                pattern: 'analysis/*.dataset.pxl',
+                saveAs: {
+                    if (params.skip_layout) {
+                        // Trim the annotate directory prefix from the output name
+                        return new File(it).name
+                    }
+                    else if (params.save_analysis_dataset || params.save_all) {
+                        return it
+                    }
+                }
+            ],
+            [
+                path: { "${params.outdir}/pixelator/logs/${meta.id}" },
+                mode: params.publish_dir_mode,
+                pattern: '*.log'
+            ],
+            [
+                path: { "${params.outdir}/pixelator" },
+                mode: params.publish_dir_mode,
+                pattern: '**/*.{report,meta}.json',
+                saveAs: { (params.save_all) ? it : null }
+            ]
+        ]
     }
 
     withName: PIXELATOR_LAYOUT {
@@ -152,9 +348,54 @@ process {
                 params.layout_algorithm ? "--layout-algorithm ${params.layout_algorithm} " : '',
             ].join(' ').trim()
         }
+
+        publishDir = [
+            [
+                path: { "${params.outdir}/pixelator" },
+                mode: params.publish_dir_mode,
+                pattern: 'layout/*.dataset.pxl',
+                saveAs: {
+                    // Trim the annotate directory prefix from the output name
+                    new File(it).name
+                }
+            ],
+            [
+                path: { "${params.outdir}/pixelator/logs/${meta.id}" },
+                mode: params.publish_dir_mode,
+                pattern: '*.log'
+            ],
+            [
+                path: { "${params.outdir}/pixelator" },
+                mode: params.publish_dir_mode,
+                pattern: '**/*.{report,meta}.json',
+                saveAs: { (params.save_all) ? it : null }
+            ]
+        ]
     }
 
     withName: PIXELATOR_REPORT {
         ext.when = { !params.skip_report }
+        publishDir = [
+            [
+                path: { "${params.outdir}/pixelator" },
+                mode: params.publish_dir_mode,
+                pattern: 'report/*.html',
+                saveAs: {
+                    // Trim the annotate directory prefix from the output name
+                    new File(it).name
+                }
+            ],
+            [
+                path: { "${params.outdir}/pixelator/logs/${meta.id}" },
+                mode: params.publish_dir_mode,
+                pattern: '*.log'
+            ],
+            [
+                path: { "${params.outdir}/pixelator" },
+                mode: params.publish_dir_mode,
+                pattern: '**/*.{report,meta}.json',
+                saveAs: { (params.save_all) ? it : null }
+            ]
+        ]
     }
 }

--- a/docs/output.md
+++ b/docs/output.md
@@ -25,7 +25,7 @@ The pipeline consists of the following steps:
 ### Preprocessing
 
 The preprocessing step uses `pixelator single-cell amplicon` to create full-length amplicon sequences from both single-end and paired-end data.
-It returns a single fastq file per sample containing fixed length amplicons.
+It returns a single FASTQ file per sample containing fixed length amplicons.
 This step will also calculate Q30 quality scores for different regions of the library.
 
 These amplicon FASTQ files are intermediate and by default not placed in the output folder with the final files delivered to users.

--- a/docs/output.md
+++ b/docs/output.md
@@ -118,9 +118,9 @@ Alternatively, set `--save_all` to keep all intermediary outputs of all steps.
 
 This step uses the `pixelator single-cell collapse` command.
 
-The `collapse` command removes duplicate reads and performs error correction.
-This is achieved using the unique pixel identifier and unique molecular identifier sequences to check for
-uniqueness, collapse and compute a read count. The command generates a QC report in JSON format.
+The `collapse` command quantifies molecules by performing error correction and detecting PCR duplicates.
+This is achieved using the unique pixel identifier and unique molecular identifier sequences to check for uniqueness, collapse and compute a read count.
+The command generates a QC report in JSON format.
 Errors are allowed when collapsing reads if `--algorithm` is set to `adjacency` (this is the default option).
 
 The output format of this command is a parquet file containing deduplicated and error-corrected molecules.

--- a/docs/output.md
+++ b/docs/output.md
@@ -148,9 +148,9 @@ Alternatively, set `--save_all` to keep all intermediary outputs of all steps.
 ### Compute connected components
 
 This step uses the `pixelator single-cell graph` command.
-The input is the edge list parquet file generated in the collapse step and after filtering it
-by count (`--graph_min_count`), the connected components of the graph (graphs) are computed and
-added to the edge list in a column called "component".
+The input is the edge list parquet file generated in the collapse step.
+The molecules from edge list are filtered by count (`--graph_min_count`) to form the edges of the connected components of the graph.
+When graphs are computed and identified, their ID names are added back to the edge list in a column called "component".
 
 The graph command has the option to recover components (technical multiplets) into smaller
 components using community detection to find and remove problematic edges

--- a/docs/output.md
+++ b/docs/output.md
@@ -28,7 +28,7 @@ The preprocessing step uses `pixelator single-cell amplicon` to create full-leng
 It returns a single fastq file per sample containing fixed length amplicons.
 This step will also calculate Q30 quality scores for different regions of the library.
 
-These amplicon FASTQ files are intermediate and by default not placed in the output folder kept in the final files delivered to users.
+These amplicon FASTQ files are intermediate and by default not placed in the output folder with the final files delivered to users.
 Set `--save_amplicon_reads` or `--save_all` to enable publishing of these files to:
 
 <details markdown="1">
@@ -61,7 +61,7 @@ uses [Cutadapt](https://cutadapt.readthedocs.io/en/stable/).
 The `adapterqc` stage checks for the presence and correctness of the pixel binding sequences.
 It also generates a QC report in JSON format. It saves processed reads as well as discarded reads (i.e. reads that did not have a match for both pixel binding sequences).
 
-These processed and discarded FASTQ reads are intermediate and by default not placed in the output folder kept in the final files delivered to users.
+These processed and discarded FASTQ reads are intermediate and by default not placed in the output folder with the final files delivered to users.
 Set `--save_qc_passed_reads` and/or `--save_qc_passed_reads` to enable publishing of these files.
 Alternatively, set `--save_all` to keep all intermediary outputs of all steps.
 
@@ -89,11 +89,11 @@ Alternatively, set `--save_all` to keep all intermediary outputs of all steps.
 
 ### Demultiplexing
 
-The `pixelator single-cell demux` command assigns a marker (barcode) to each read. It also generates QC report in
-JSON format. It saves processed reads (one per antibody) as well as discarded reads with no match to the
+The `pixelator single-cell demux` command assigns each read to a marker (with a certain barcode) file. It also generates QC report in
+JSON format. It saves processed reads (one file per antibody) as well as discarded reads (in a different file) with no match to the
 given barcodes/antibodies.
 
-These processed and discarded FASTQ reads are intermediate and by default not placed in the output folder kept in the final files delivered to users.
+These processed and discarded FASTQ reads are intermediate and by default not placed in the output folder with the final files delivered to users.
 Set `--save_demux_failed_reads` and/or `--save_demux_processed_reads` to enable publishing of these files.
 Alternatively, set `--save_all` to keep all intermediary outputs of all steps.
 
@@ -123,9 +123,9 @@ This is achieved using the unique pixel identifier and unique molecular identifi
 uniqueness, collapse and compute a read count. The command generates a QC report in JSON format.
 Errors are allowed when collapsing reads if `--algorithm` is set to `adjacency` (this is the default option).
 
-The output format of this command is a parquet file containing deduplicated and error-corrected reads.
+The output format of this command is a parquet file containing deduplicated and error-corrected molecules.
 
-The collapsed reads are intermediate and by default not placed in the output folder kept in the final files delivered to users.
+The collapsed reads are intermediate and by default not placed in the output folder with the final files delivered to users.
 Set `--save_collapsed_reads` to enable publishing of these files.
 Alternatively, set `--save_all` to keep all intermediary outputs of all steps.
 
@@ -153,12 +153,12 @@ by count (`--graph_min_count`), the connected components of the graph (graphs) a
 added to the edge list in a column called "component".
 
 The graph command has the option to recover components (technical multiplets) into smaller
-components using community detection to find and remove problematic edges.
-(See `--multiplet_recovery`). The information to keep track of the original and
+components using community detection to find and remove problematic edges
+(see `--multiplet_recovery`). These new component IDs are then stored in the "component" column. The information to keep track of the original and
 newly recovered components are stored in a file (components_recovered.csv).
 This file is not included in the output folder by default, but can be included by passing `--save_recovered_components`.
 
-The edgelist is intermediate and by default not placed in the output folder kept in the final files delivered to users.
+The edgelist is intermediate and by default not placed in the output folder with the final files delivered to users.
 Set `--save_edgelist` to enable publishing of these file.
 
 Alternatively, set `--save_all` to keep all intermediary outputs of all steps.
@@ -187,8 +187,8 @@ Alternatively, set `--save_all` to keep all intermediary outputs of all steps.
 
 This step uses the `pixelator single-cell annotate` command.
 
-The annotate command takes as input the edge list file generated in the graph command. It parses, and filters the
-edgelist to find putative cells, and it will generate a PXL file containing the edgelist, and an
+The annotate command takes as input the molecule list file generated in the graph command. It parses, and filters the
+molecules grouped by "component" ID to find putative cells, and it will generate a PXL file containing the edges of the graphs in an edgelist, and an
 (AnnData object)[https://anndata.readthedocs.io/en/latest/] as well as some useful metadata.
 
 Some summary statistics before filtering are stored in `raw_components_metrics.csv.gz`.
@@ -203,7 +203,7 @@ Set `--save_annotate_dataset` to include these files.
 - `pixelator`
 
   - `annotate`
-    - `<sample-id>.annotate.dataset.pxl`: The procesed PXL dataset,
+    - `<sample-id>.annotate.dataset.pxl`: The annotated PXL dataset,
     - `<sample-id>.meta.json`: Command invocation metadata.
     - `<sample-id>.raw_components_metrics.csv.gz`
     - `<sample-id>.report.json`: Statistics for the analysis step.
@@ -214,8 +214,8 @@ Set `--save_annotate_dataset` to include these files.
 ### Downstream analysis
 
 This step uses the `pixelator single-cell analysis` command.
-Downstream analysis is performed on the `pxl` file generated by the previous stage.
-The results of the analysis are added to the pxl file.
+Downstream analyses are performed on the PXL file generated by the previous stage.
+The results of the analysis are added to the PXL file produced in this stage.
 
 Currently, the following analysis are performed:
 
@@ -280,7 +280,7 @@ and generate a report in HTML format for each sample.
 
 This step can be skipped using the `--skip_report` option.
 
-More information on the report can be found in the [pixelator documentation](https://software.pixelgen.com/pixelator/outputs/web-report/)
+More information on the report can be found in the [pixelator documentation](https://software.pixelgen.com/pixelator/outputs/qc-report/)
 
 <details markdown="1">
 <summary>Output files</summary>
@@ -310,8 +310,8 @@ More information on the report can be found in the [pixelator documentation](htt
 
 ## Output directory structure
 
-With default parameters, the pixelator pipeline output directory will only include the most "complete" PXL file
-generated by the pipeline and an interactive HTML report per sample.
+With default parameters, the pixelator pipeline output directory will only include the latest PXL file
+generated by the pipeline (with the most "complete" information) and an interactive HTML report per sample.
 The PXL dataset files can be from either the `annotate`, `analysis` or `layout` step.
 
 With default parameters, the `<sample-id>.layout.datasets.pxl` will be copied to the output directory.

--- a/nextflow.config
+++ b/nextflow.config
@@ -62,6 +62,21 @@ params {
     colocalization_n_permutations = 50
     colocalization_min_region_count = 5
 
+    // Output options
+    save_amplicon_reads = false
+    save_qc_passed_reads = false
+    save_qc_failed_reads = false
+    save_demux_processed_reads = false
+    save_demux_failed_reads = false
+    save_collapsed_reads = false
+    save_recovered_components = false
+    save_edgelist = false
+    save_annotate_dataset = false
+    save_raw_component_metrics = false
+    save_analysis_dataset = false
+
+    save_all = false
+
     // layout options
     no_node_marker_counts = false
     layout_algorithm = "pmds_3d"

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -45,7 +45,21 @@
                 }
             }
         },
-        "preqc_options": {
+        "amplicon_options": {
+            "title": "Amplicon generation options",
+            "type": "object",
+            "fa_icon": "fas fa-circle",
+            "properties": {
+                "save_amplicon_reads": {
+                    "fa_icon": "fas fa-save",
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Save intermediate amplicon reads generated from the raw input reads.",
+                    "help": "By default, generated amplicon FastQ files will not be saved to the results directory. Specify this flag (or set to true in your config file) to copy these files to the results directory when complete."
+                }
+            }
+        },
+        "qc_options": {
             "title": "QC/Filtering/Trimming options",
             "type": "object",
             "fa_icon": "fas fa-terminal",
@@ -96,13 +110,7 @@
                     "fa_icon": "fas g",
                     "description": "Remove PolyG sequences (length of 10 or more)",
                     "type": "boolean"
-                }
-            }
-        },
-        "adapterqc_options": {
-            "title": "Adapter QC Options",
-            "type": "object",
-            "properties": {
+                },
                 "adapterqc_mismatches": {
                     "fa_icon": "fas not-equal",
                     "description": "The number of mismatches allowed (in percentage) [default: 0.1; 0.0<=x<=0.9]",
@@ -110,6 +118,20 @@
                     "default": 0.1,
                     "minimum": 0.0,
                     "maximum": 0.9
+                },
+                "save_qc_passed_reads": {
+                    "fa_icon": "fas fa-save",
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Save intermediate qc read files containing all reads that passed the filters.",
+                    "help": "By default, filtered read FastQ files after QC will not be saved to the results directory. Specify this flag (or set to true in your config file) to copy these files to the results directory when complete."
+                },
+                "save_qc_failed_reads": {
+                    "fa_icon": "fas fa-save",
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Save intermediate qc read files containing all reads that failed the filters.",
+                    "help": "By default, FastQ files with reads that failed QC will not be saved to the results directory. Specify this flag (or set to true in your config file) to copy these files to the results directory when complete."
                 }
             }
         },
@@ -130,6 +152,20 @@
                     "description": "The minimum length of the barcode that must overlap when matching",
                     "help_text": "If you set this argument it will overrule the value from the chosen design",
                     "type": "integer"
+                },
+                "save_demux_processed_reads": {
+                    "fa_icon": "fas fa-save",
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Save intermediate qc read files containing all reads that containt valid antibody barcodes.",
+                    "help": "By default, FastQ files containing reads with valid antibody barcodes will not be saved to the results directory. Specify this flag (or set to true in your config file) to copy these files to the results directory when complete."
+                },
+                "save_demux_failed_reads": {
+                    "fa_icon": "fas fa-save",
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Save intermediate qc read files containing all reads that failed the filters.",
+                    "help": "By default, FastQ files containing reads without valid antibody barcodes will not be saved to the results directory. Specify this flag (or set to true in your config file) to copy these files to the results directory when complete."
                 }
             }
         },
@@ -177,6 +213,13 @@
                 "collapse_use_counts": {
                     "description": "Use counts when collapsing (the difference in counts between two molecules must be more than double in order to be collapsed)",
                     "type": "boolean"
+                },
+                "save_collapsed_reads": {
+                    "fa_icon": "fas fa-save",
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Save an intermediate parquet file containing collapsed read information.",
+                    "help": "By default, intermediate collapsed reads will not be saved to the results directory. Specify this flag (or set to true in your config file) to copy these files to the results directory when complete."
                 }
             }
         },
@@ -206,6 +249,20 @@
                     "minimum": 1,
                     "maximum": 50,
                     "hidden": true
+                },
+                "save_edgelist": {
+                    "fa_icon": "fas fa-save",
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Save an intermediate csv file containing the unfiltered graph edgelist.",
+                    "help": "By default, the unfiltered edgelist will not be saved to the results directory. Specify this flag (or set to true in your config file) to copy these files to the results directory when complete."
+                },
+                "save_recovered_components": {
+                    "fa_icon": "fas fa-save",
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Save an intermediate csv file containing the recovered components after multiplet recovery.",
+                    "help": "By default, the recovered component will not be saved to the results directory. Specify this flag (or set to true in your config file) to copy these files to the results directory when complete."
                 }
             }
         },
@@ -231,6 +288,20 @@
                     "description": "Enable aggregate calling, information on potential aggregates will be added to the output data",
                     "type": "boolean",
                     "default": true
+                },
+                "save_raw_component_metrics": {
+                    "fa_icon": "fas fa-save",
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Save the raw_component_metrics.csv file from the annotate stage.",
+                    "help": "By default, the raw_component_metrics CSV file after annotate will not be saved to the results directory. Specify this flag (or set to true in your config file) to copy these files to the results directory when complete."
+                },
+                "save_annotate_dataset": {
+                    "fa_icon": "fas fa-save",
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Save the PXL dataset after the annotate stage.",
+                    "help": "By default, the PXL file after annotate will not be saved to the results directory unless `--skip_analysis` and `--skip_layout` is passed. Specify this flag (or set to true in your config file) to copy these files to the results directory when complete."
                 }
             }
         },
@@ -298,6 +369,13 @@
                     "description": "The minimum number of counts in a region for it to be considered valid for computing colocalization",
                     "default": 5,
                     "minimum": 0
+                },
+                "save_analysis_dataset": {
+                    "fa_icon": "fas fa-save",
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Save the PXL dataset after the analysis stage.",
+                    "help": "By default, the PXL dataset after the analysis stage will only be saved be saved when `--skip_layout` is passed. Specify this flag (or set to true in your config file) to copy these files to the results directory when complete."
                 }
             }
         },
@@ -341,6 +419,13 @@
                     "type": "string",
                     "description": "Override the container image reference to use for all steps using the `pixelator` command.",
                     "help_text": "Use this to force the pipeline to use a different image version in all steps that use the pixelator command.\nThe pipeline is not guaranteed to work when using different pixelator versions."
+                },
+                "save_all": {
+                    "fa_icon": "fas fa-save",
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Save all intermediate results.",
+                    "help": "This option is equivalent to passing:\n`--save_amplicon_reads --save_qc_passed_reads --save_qc_failed_reads --save_demux_processed_reads --save_demux_failed_reads --save_collapsed_reads --save_edgelist --save_recovered_components --save_annotate_dataset --save_analysis_dataset`"
                 }
             }
         },
@@ -525,10 +610,10 @@
             "$ref": "#/definitions/input_output_options"
         },
         {
-            "$ref": "#/definitions/preqc_options"
+            "$ref": "#/definitions/amplicon_options"
         },
         {
-            "$ref": "#/definitions/adapterqc_options"
+            "$ref": "#/definitions/qc_options"
         },
         {
             "$ref": "#/definitions/demux_options"

--- a/workflows/pixelator.nf
+++ b/workflows/pixelator.nf
@@ -192,7 +192,8 @@ workflow PIXELATOR {
     //
     // MODULE: Run pixelator single-cell layout
     //
-    PIXELATOR_LAYOUT ( ch_analysed )
+    ch_layout_input = params.skip_analysis ? ch_annotated : ch_analysed
+    PIXELATOR_LAYOUT ( ch_layout_input )
     ch_layout = PIXELATOR_LAYOUT.out.dataset
     ch_versions = ch_versions.mix(PIXELATOR_LAYOUT.out.versions.first())
 


### PR DESCRIPTION
## Description 

This PR removes a lot of intemediate output files that are rarely used from the output directory by default.
They can still be included using various `--save_*` flags:

- `save_amplicon_reads`
- `save_qc_passed_reads`
- `save_qc_failed_reads`
- `save_demux_processed_reads`
- `save_demux_failed_reads`
- `save_collapsed_reads`
- `save_recovered_components`
- `save_edgelist`
- `save_annotate_dataset`
- `save_raw_component_metrics`
- `save_analysis_dataset`

- `save_all`

The final PXL datasets are now stored in the outputdir base directory (depending on if analysis and/or layout was run). This is to prevent users from accidentally using PXL files from annotate instead of analysis.
