### PR TITLE
Patch release 1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [[PR #102](https://github.com/nf-core/pixelator/pull/101)] - Restructure output directory
 - [[PR #103](https://github.com/nf-core/pixelator/pull/103)] - Make rate-diff the default transformation method when computing colocalization
 - [[PR #104](https://github.com/nf-core/pixelator/pull/104)] - Update to pixelator 0.18.1
+- [[PR #106](https://github.com/nf-core/pixelator/pull/106)] - Update to pixelator 0.18.2
 
 ### Software dependencies
 
 | Dependency  | Old version | New version |
 | ----------- | ----------- | ----------- |
-| `pixelator` | 0.17.1      | 0.18.1      |
+| `pixelator` | 0.17.1      | 0.18.2      |
 
 > [!NOTE]
 > Dependency has been **updated** if both old and new version information is present.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [[1.3.0](https://github.com/nf-core/pixelator/releases/tag/1.3.0)] - 2024-07-15
+## [[1.3.0](https://github.com/nf-core/pixelator/releases/tag/1.3.0)] - 2024-07-17
 
 ### Enhancements & fixes
 

--- a/conf/test_panel_v2.config
+++ b/conf/test_panel_v2.config
@@ -24,10 +24,8 @@ params {
     max_time   = '6.h'
 
     // Input data
-    // input          = params.pipelines_testdata_base_path + 'pixelator/samplesheet/samplesheet_v2.csv'
-    // input_basedir  = params.pipelines_testdata_base_path + 'pixelator/testdata/'
-    input            = params.pipelines_testdata_base_path + 'samplesheet/samplesheet_v2.csv'
-    input_basedir    = params.pipelines_testdata_base_path + 'testdata/'
+    input          = params.pipelines_testdata_base_path + 'pixelator/samplesheet/samplesheet_v2.csv'
+    input_basedir  = params.pipelines_testdata_base_path + 'pixelator/testdata/'
 
     multiplet_recovery                = true
     min_size                          = 2

--- a/conf/test_panel_v2.config
+++ b/conf/test_panel_v2.config
@@ -38,7 +38,7 @@ params {
 
     // For now skip the layout step since it is very slow on these
     // small test datasets
-    skip_layout      = true
+    skip_layout      = false
     // using this since the default pmds_3d does not work on very small graphs
     layout_algorithm = "fruchterman_reingold_3d"
 }

--- a/modules/local/pixelator/collect_metadata.nf
+++ b/modules/local/pixelator/collect_metadata.nf
@@ -8,8 +8,8 @@ process PIXELATOR_COLLECT_METADATA {
 
     conda "bioconda::pixelator=0.17.1"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/pixelator:0.18.1--pyhdfd78af_0' :
-        'biocontainers/pixelator:0.18.1--pyhdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/pixelator:0.18.2--pyhdfd78af_0' :
+        'biocontainers/pixelator:0.18.2--pyhdfd78af_0' }"
 
     input:
 

--- a/modules/local/pixelator/list_options.nf
+++ b/modules/local/pixelator/list_options.nf
@@ -4,8 +4,8 @@ process PIXELATOR_LIST_OPTIONS {
 
     conda "bioconda::pixelator=0.17.1"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/pixelator:0.18.1--pyhdfd78af_0' :
-        'biocontainers/pixelator:0.18.1--pyhdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/pixelator:0.18.2--pyhdfd78af_0' :
+        'biocontainers/pixelator:0.18.2--pyhdfd78af_0' }"
 
     output:
     path "design_options.txt"     , emit: designs

--- a/modules/local/pixelator/single-cell/amplicon/main.nf
+++ b/modules/local/pixelator/single-cell/amplicon/main.nf
@@ -5,8 +5,8 @@ process PIXELATOR_AMPLICON {
 
     conda "bioconda::pixelator=0.17.1"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/pixelator:0.18.1--pyhdfd78af_0' :
-        'biocontainers/pixelator:0.18.1--pyhdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/pixelator:0.18.2--pyhdfd78af_0' :
+        'biocontainers/pixelator:0.18.2--pyhdfd78af_0' }"
 
     input:
     tuple val(meta), path(reads)

--- a/modules/local/pixelator/single-cell/analysis/main.nf
+++ b/modules/local/pixelator/single-cell/analysis/main.nf
@@ -4,8 +4,8 @@ process PIXELATOR_ANALYSIS {
 
     conda "bioconda::pixelator=0.17.1"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/pixelator:0.18.1--pyhdfd78af_0' :
-        'biocontainers/pixelator:0.18.1--pyhdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/pixelator:0.18.2--pyhdfd78af_0' :
+        'biocontainers/pixelator:0.18.2--pyhdfd78af_0' }"
 
     input:
     tuple val(meta), path(data)

--- a/modules/local/pixelator/single-cell/annotate/main.nf
+++ b/modules/local/pixelator/single-cell/annotate/main.nf
@@ -5,8 +5,8 @@ process PIXELATOR_ANNOTATE {
 
     conda "bioconda::pixelator=0.17.1"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/pixelator:0.18.1--pyhdfd78af_0' :
-        'biocontainers/pixelator:0.18.1--pyhdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/pixelator:0.18.2--pyhdfd78af_0' :
+        'biocontainers/pixelator:0.18.2--pyhdfd78af_0' }"
 
     input:
     tuple val(meta), path(dataset), path(panel_file), val(panel)

--- a/modules/local/pixelator/single-cell/collapse/main.nf
+++ b/modules/local/pixelator/single-cell/collapse/main.nf
@@ -4,8 +4,8 @@ process PIXELATOR_COLLAPSE {
 
     conda "bioconda::pixelator=0.17.1"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/pixelator:0.18.1--pyhdfd78af_0' :
-        'biocontainers/pixelator:0.18.1--pyhdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/pixelator:0.18.2--pyhdfd78af_0' :
+        'biocontainers/pixelator:0.18.2--pyhdfd78af_0' }"
 
     input:
     tuple val(meta), path(reads), path(panel_file), val(panel)

--- a/modules/local/pixelator/single-cell/demux/main.nf
+++ b/modules/local/pixelator/single-cell/demux/main.nf
@@ -5,8 +5,8 @@ process PIXELATOR_DEMUX {
 
     conda "bioconda::pixelator=0.17.1"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/pixelator:0.18.1--pyhdfd78af_0' :
-        'biocontainers/pixelator:0.18.1--pyhdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/pixelator:0.18.2--pyhdfd78af_0' :
+        'biocontainers/pixelator:0.18.2--pyhdfd78af_0' }"
 
     input:
     tuple val(meta), path(reads), path(panel_file), val(panel)

--- a/modules/local/pixelator/single-cell/graph/main.nf
+++ b/modules/local/pixelator/single-cell/graph/main.nf
@@ -5,8 +5,8 @@ process PIXELATOR_GRAPH {
 
     conda "bioconda::pixelator=0.17.1"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/pixelator:0.18.1--pyhdfd78af_0' :
-        'biocontainers/pixelator:0.18.1--pyhdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/pixelator:0.18.2--pyhdfd78af_0' :
+        'biocontainers/pixelator:0.18.2--pyhdfd78af_0' }"
 
     input:
     tuple val(meta), path(edge_list)

--- a/modules/local/pixelator/single-cell/layout/main.nf
+++ b/modules/local/pixelator/single-cell/layout/main.nf
@@ -5,8 +5,8 @@ process PIXELATOR_LAYOUT {
 
     conda "bioconda::pixelator=0.17.1"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/pixelator:0.18.1--pyhdfd78af_0' :
-        'biocontainers/pixelator:0.18.1--pyhdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/pixelator:0.18.2--pyhdfd78af_0' :
+        'biocontainers/pixelator:0.18.2--pyhdfd78af_0' }"
 
     input:
     tuple val(meta), path(data)

--- a/modules/local/pixelator/single-cell/qc/main.nf
+++ b/modules/local/pixelator/single-cell/qc/main.nf
@@ -5,8 +5,8 @@ process PIXELATOR_QC {
 
     conda "bioconda::pixelator=0.17.1"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/pixelator:0.18.1--pyhdfd78af_0' :
-        'biocontainers/pixelator:0.18.1--pyhdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/pixelator:0.18.2--pyhdfd78af_0' :
+        'biocontainers/pixelator:0.18.2--pyhdfd78af_0' }"
 
     input:
     tuple val(meta), path(reads)

--- a/modules/local/pixelator/single-cell/report/main.nf
+++ b/modules/local/pixelator/single-cell/report/main.nf
@@ -5,8 +5,8 @@ process PIXELATOR_REPORT {
 
     conda "bioconda::pixelator=0.17.1"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/pixelator:0.18.1--pyhdfd78af_0' :
-        'biocontainers/pixelator:0.18.1--pyhdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/pixelator:0.18.2--pyhdfd78af_0' :
+        'biocontainers/pixelator:0.18.2--pyhdfd78af_0' }"
 
     input:
     tuple val(meta), path(panel_file), val(panel)


### PR DESCRIPTION


## [[1.3.1](https://github.com/nf-core/pixelator/releases/tag/1.3.1)] - 2024-07-31

### Enhancements & fixes

- [[PR #107](https://github.com/nf-core/pixelator/pull/107)] - Fix conda version tag to use pixelator 0.18.2