### PR TITLE
Remove `--save_recovered_components` options for graph outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [[PR #111](https://github.com/nf-core/pixelator/pull/111)] - Template update for nf-core/tools v3.0.2
 - [[PR #112](https://github.com/nf-core/pixelator/pull/112)] - Add graph refinement options for pixelator 0.19
 - [[PR #113](https://github.com/nf-core/pixelator/pull/113)] - Fix validation issues after nf-core/tools v3.0.2 update
+- [[PR #114](https://github.com/nf-core/pixelator/pull/114)] - Remove `--save_recovered_components` options for graph outputs
 
 ### Parameters
 
@@ -23,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 | `--validationShowHiddenParams`       |                                          |
 | `--leiden_iterations`                | `--graph_max_refinement_recursion_depth` |
 |                                      | `--graph_max_edges_to_split`             |
+|                                      | `--graph_max_edges_to_split`             |
+| `--save_recovered_components`        |                                          |
 
 > [!NOTE]
 > Parameter has been **updated** if both old and new parameter information is present.

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -231,12 +231,6 @@ process {
             [
                 path: { "${params.outdir}/pixelator" },
                 mode: params.publish_dir_mode,
-                pattern: 'graph/*.components_recovered.csv',
-                saveAs: { (params.save_recovered_components || params.save_all) ? it : null }
-            ],
-            [
-                path: { "${params.outdir}/pixelator" },
-                mode: params.publish_dir_mode,
                 pattern: 'graph/*edgelist.parquet',
                 saveAs: { (params.save_edgelist || params.save_all) ? it : null }
             ],

--- a/conf/test.config
+++ b/conf/test.config
@@ -32,7 +32,7 @@ params {
     multiplet_recovery                = true
     min_size                          = 2
     max_size                          = 100000
-    dynamic_filtering                 = null
+    dynamic_filter                    = null
     compute_polarization              = true
     use_full_bipartite                = true
     colocalization_min_region_count   = 0

--- a/conf/test.config
+++ b/conf/test.config
@@ -32,6 +32,7 @@ params {
     multiplet_recovery                = true
     min_size                          = 2
     max_size                          = 100000
+    dynamic_filtering                 = null
     compute_polarization              = true
     use_full_bipartite                = true
     colocalization_min_region_count   = 0

--- a/conf/test.config
+++ b/conf/test.config
@@ -30,7 +30,7 @@ params {
     input_basedir                     = params.pipelines_testdata_base_path + 'pixelator/testdata'
 
     multiplet_recovery                = true
-    min_size                          = 2
+    min_size                          = null
     max_size                          = 100000
     dynamic_filter                    = null
     compute_polarization              = true

--- a/conf/test_panel_v2.config
+++ b/conf/test_panel_v2.config
@@ -33,6 +33,7 @@ params {
     multiplet_recovery                = true
     min_size                          = 2
     max_size                          = 100000
+    dynamic_filtering                 = nu
     compute_polarization              = true
     use_full_bipartite                = true
     colocalization_min_region_count   = 0

--- a/conf/test_panel_v2.config
+++ b/conf/test_panel_v2.config
@@ -33,7 +33,7 @@ params {
     multiplet_recovery                = true
     min_size                          = 2
     max_size                          = 100000
-    dynamic_filtering                 = nu
+    dynamic_filter                    = null
     compute_polarization              = true
     use_full_bipartite                = true
     colocalization_min_region_count   = 0

--- a/docs/output.md
+++ b/docs/output.md
@@ -156,9 +156,7 @@ When graphs are computed and identified, their ID names are added back to the ed
 
 The graph command has the option to recover components (technical multiplets) into smaller
 components using community detection to find and remove problematic edges
-(see `--multiplet_recovery`). These new component IDs are then stored in the "component" column. The information to keep track of the original and
-newly recovered components are stored in a file (components_recovered.csv).
-This file is not included in the output folder by default, but can be included by passing `--save_recovered_components`.
+(see `--multiplet_recovery`). These new component IDs are then stored in the "component" column.
 
 The edge list is intermediate and by default not placed in the output folder with the final files delivered to users.
 Set `--save_edgelist` to enable publishing of these file.

--- a/modules/local/pixelator/single-cell/graph/main.nf
+++ b/modules/local/pixelator/single-cell/graph/main.nf
@@ -13,7 +13,6 @@ process PIXELATOR_GRAPH {
 
     output:
     tuple val(meta), path("graph/*.edgelist.parquet")         , emit: edgelist
-    tuple val(meta), path("graph/*.components_recovered.csv"), emit: components_recovered, optional: true
     tuple val(meta), path("graph/*.report.json")             , emit: report_json
     tuple val(meta), path("graph/*.meta.json")               , emit: input_params
     tuple val(meta), path("graph/*")                         , emit: all_results

--- a/nextflow.config
+++ b/nextflow.config
@@ -70,7 +70,6 @@ params {
     save_demux_processed_reads         = false
     save_demux_failed_reads            = false
     save_collapsed_reads               = false
-    save_recovered_components          = false
     save_edgelist                      = false
     save_annotate_dataset              = false
     save_raw_component_metrics         = false

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -276,7 +276,8 @@
                     "type": "integer"
                 },
                 "dynamic_filter": {
-                    "description": " Enable the estimation of dynamic size filters using a log-rank approach both: estimate both min and max size, min: estimate min size (--min-size), max: estimate max size (--max-size)",
+                    "description": "Enable the estimation of dynamic size filters using a log-rank approach.",
+                    "help_text": "Following options are available:\n- both: estimates both minimum and maximum component size\n- min: estimates the minimum component size (or uses {MINIMUM_N_EDGES_CELL_SIZE} edges, whichever is smallest)\n- max: estimates the maximum component size.\n\nNote that this cannot be set at the same time as `--min-size` or `--max-size`.",
                     "type": "string",
                     "enum": ["both", "min", "max"],
                     "default": "min"

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -260,13 +260,6 @@
                     "default": false,
                     "description": "Save an intermediate CSV file containing the unfiltered graph edge list.",
                     "help": "By default, the unfiltered edge list will not be saved to the results directory. Specify this flag (or set to `true` in your config file) to copy these files to the results directory when complete."
-                },
-                "save_recovered_components": {
-                    "fa_icon": "fas fa-save",
-                    "type": "boolean",
-                    "default": false,
-                    "description": "Save an intermediate CSV file containing the recovered components after multiplet recovery.",
-                    "help": "By default, the recovered component will not be saved to the results directory. Specify this flag (or set to `true` in your config file) to copy these files to the results directory when complete."
                 }
             }
         },

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -428,7 +428,7 @@
                     "type": "boolean",
                     "default": false,
                     "description": "Save all intermediate results.",
-                    "help": "This option is equivalent to passing:\n`--save_amplicon_reads --save_qc_passed_reads --save_qc_failed_reads --save_demux_processed_reads --save_demux_failed_reads --save_collapsed_reads --save_edgelist --save_recovered_components --save_annotate_dataset --save_analysis_dataset`"
+                    "help": "This option is equivalent to passing:\n`--save_amplicon_reads --save_qc_passed_reads --save_qc_failed_reads --save_demux_processed_reads --save_demux_failed_reads --save_collapsed_reads --save_edgelist --save_annotate_dataset --save_analysis_dataset`"
                 }
             }
         },

--- a/subworkflows/local/utils_nfcore_pixelator_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_pixelator_pipeline/main.nf
@@ -100,13 +100,13 @@ workflow PIPELINE_INITIALISATION {
     // Create a set of valid pixelator options to pass to --design
     ch_design_options = PIXELATOR_LIST_OPTIONS.out.designs
         .splitText()
-        .map( text -> text.trim())
+        .map { it.trim() }
         .reduce( new HashSet() ) { prev, curr -> prev << curr }
 
     // Create a set of valid pixelator panel keys to pass using --panel
     ch_panel_options = PIXELATOR_LIST_OPTIONS.out.panels
         .splitText()
-        .map( text -> text.trim())
+        .map { it.trim() }
         .reduce( new HashSet() ) { prev, curr -> prev << curr }
 
     //


### PR DESCRIPTION
## Description

- Remove the `--save_recovered_components` flag. Pixelator 0.19 drops this output file.
- Update the help description for `--dynamic-filter`