### PR TITLE
Add `process_long` to PIXELATOR_COLLAPSE

### DIFF
--- a/modules/local/pixelator/single-cell/collapse/main.nf
+++ b/modules/local/pixelator/single-cell/collapse/main.nf
@@ -1,6 +1,7 @@
 process PIXELATOR_COLLAPSE {
     tag "$meta.id"
     label 'process_medium'
+    label 'process_long'
 
     conda "bioconda::pixelator=0.18.2"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?


### PR DESCRIPTION
Allow COLLAPSE to run longer by default.