### PR TITLE
Load missing pna modules

### DIFF
--- a/modules/local/pixelator/single-cell-mpx/amplicon/tests/main.nf.test.snap
+++ b/modules/local/pixelator/single-cell-mpx/amplicon/tests/main.nf.test.snap
@@ -37,9 +37,9 @@
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "24.10.6"
+            "nextflow": "25.04.2"
         },
-        "timestamp": "2025-05-06T15:06:14.972053842"
+        "timestamp": "2025-05-22T17:14:02.644424062"
     },
     "Test MPX amplicon - stub": {
         "content": [
@@ -142,8 +142,8 @@
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "24.10.6"
+            "nextflow": "25.04.2"
         },
-        "timestamp": "2025-05-06T15:05:40.728453379"
+        "timestamp": "2025-05-22T17:13:19.244421007"
     }
 }

--- a/modules/local/pixelator/single-cell-pna/amplicon/tests/main.nf.test.snap
+++ b/modules/local/pixelator/single-cell-pna/amplicon/tests/main.nf.test.snap
@@ -9,15 +9,15 @@
                         "panel": "proxiome-immuno-155",
                         "technology": "pna"
                     },
-                    "PNA055_Sample07_filtered_S7.amplicon.fq.zst:md5,97f16ddab1b3054e45fab989b7ed4a0b"
+                    "PNA055_Sample07_filtered_S7.amplicon.fq.zst:md5,460f0dd9af7c5ebec8bcad76e3964b7d"
                 ]
             ]
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "24.10.5"
+            "nextflow": "25.04.2"
         },
-        "timestamp": "2025-04-16T15:53:13.365678723"
+        "timestamp": "2025-05-22T17:25:26.962907069"
     },
     "report_json": {
         "content": [
@@ -29,15 +29,15 @@
                         "panel": "proxiome-immuno-155",
                         "technology": "pna"
                     },
-                    "PNA055_Sample07_filtered_S7.report.json:md5,185bd6f2e656bb83adeb29fbcb77a33a"
+                    "PNA055_Sample07_filtered_S7.report.json:md5,ae3608057ebf0eceaae5b3c0efa8320b"
                 ]
             ]
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "24.10.5"
+            "nextflow": "25.04.2"
         },
-        "timestamp": "2025-04-16T15:53:13.431630973"
+        "timestamp": "2025-05-22T17:25:27.100151311"
     },
     "metadata_json": {
         "content": [
@@ -49,14 +49,14 @@
                         "panel": "proxiome-immuno-155",
                         "technology": "pna"
                     },
-                    "PNA055_Sample07_filtered_S7.meta.json:md5,9b4e3d05a2eed36db659202d1add3ee0"
+                    "PNA055_Sample07_filtered_S7.meta.json:md5,59094765101eb355c10938eff88a24e1"
                 ]
             ]
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "24.10.5"
+            "nextflow": "25.04.2"
         },
-        "timestamp": "2025-04-16T15:53:13.504268652"
+        "timestamp": "2025-05-22T17:25:27.236295681"
     }
 }

--- a/modules/local/pixelator/single-cell-pna/analysis/tests/main.nf.test.snap
+++ b/modules/local/pixelator/single-cell-pna/analysis/tests/main.nf.test.snap
@@ -18,15 +18,15 @@
                 "    \"sample_id\": \"PNA055_Sample07_filtered_S7\",",
                 "    \"product_id\": \"single-cell-pna\",",
                 "    \"report_type\": \"analysis\",",
-                "    \"proximity\": null,",
-                "    \"k_cores\": null,"
+                "    \"proximity\": {},",
+                "    \"k_cores\": {"
             ]
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "24.10.5"
+            "nextflow": "25.04.2"
         },
-        "timestamp": "2025-04-16T15:53:34.421336115"
+        "timestamp": "2025-05-22T17:31:47.907028898"
     },
     "metadata_json": {
         "content": [
@@ -38,14 +38,14 @@
                         "panel": "proxiome-immuno-155",
                         "technology": "pna"
                     },
-                    "PNA055_Sample07_filtered_S7.meta.json:md5,2df457e4a597bc5635c75141cffb6d7b"
+                    "PNA055_Sample07_filtered_S7.meta.json:md5,2a6eaa66228775591525f74416f0b87f"
                 ]
             ]
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "24.10.5"
+            "nextflow": "25.04.2"
         },
-        "timestamp": "2025-04-16T15:53:34.410759655"
+        "timestamp": "2025-05-22T17:31:47.884573212"
     }
 }

--- a/modules/local/pixelator/single-cell-pna/demux/tests/main.nf.test.snap
+++ b/modules/local/pixelator/single-cell-pna/demux/tests/main.nf.test.snap
@@ -149,14 +149,14 @@
                         "panel": "proxiome-immuno-155",
                         "technology": "pna"
                     },
-                    "PNA055_Sample07_filtered_S7.meta.json:md5,857222ab33b343937c187f083ca2c491"
+                    "PNA055_Sample07_filtered_S7.meta.json:md5,76e64fbe2518c5c56da1316c2e6afbd3"
                 ]
             ]
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "24.10.5"
+            "nextflow": "25.04.2"
         },
-        "timestamp": "2025-04-16T15:55:26.687009116"
+        "timestamp": "2025-05-22T17:34:08.919733329"
     }
 }

--- a/modules/local/pixelator/single-cell-pna/graph/tests/main.nf.test.snap
+++ b/modules/local/pixelator/single-cell-pna/graph/tests/main.nf.test.snap
@@ -21,15 +21,15 @@
                         "panel": "proxiome-immuno-155",
                         "technology": "pna"
                     },
-                    "PNA055_Sample07_filtered_S7.report.json:md5,44c0c42d4dbb382f7d1541719182ca08"
+                    "PNA055_Sample07_filtered_S7.report.json:md5,25236e45949c32ce93506db00eda246a"
                 ]
             ]
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "24.10.5"
+            "nextflow": "25.04.2"
         },
-        "timestamp": "2025-04-16T15:56:26.49718139"
+        "timestamp": "2025-05-22T17:35:26.902757909"
     },
     "metadata_json": {
         "content": [
@@ -41,14 +41,14 @@
                         "panel": "proxiome-immuno-155",
                         "technology": "pna"
                     },
-                    "PNA055_Sample07_filtered_S7.meta.json:md5,b15fffdd71ae59f5e36f7237e76b1b98"
+                    "PNA055_Sample07_filtered_S7.meta.json:md5,a5fb5308aa82dd9b96d36defdea5e6a8"
                 ]
             ]
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "24.10.5"
+            "nextflow": "25.04.2"
         },
-        "timestamp": "2025-04-16T15:56:26.489197437"
+        "timestamp": "2025-05-22T17:35:26.895238955"
     }
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -446,3 +446,4 @@ validation {
 
 // Load modules.config for DSL2 module specific options
 includeConfig 'conf/modules.config'
+includeConfig 'conf/modules.pna.config'

--- a/tests/default_pna.nf.test
+++ b/tests/default_pna.nf.test
@@ -7,10 +7,13 @@ nextflow_pipeline {
 
         when {
             params {
-                pipelines_testdata_base_path = "https://raw.githubusercontent.com/nf-core/test-datasets/pixelator/"
-                input                        = "$pipelines_testdata_base_path/samplesheet/pna/samplesheet_pna.csv"
-                input_basedir                = "$pipelines_testdata_base_path/testdata/pna/"
-                outdir                       = "$outputDir"
+                pipelines_testdata_base_path           = "https://raw.githubusercontent.com/nf-core/test-datasets/pixelator/"
+                input                                  = "$pipelines_testdata_base_path/samplesheet/pna/samplesheet_pna.csv"
+                input_basedir                          = "$pipelines_testdata_base_path/testdata/pna/"
+                outdir                                 = "$outputDir"
+
+                pna_graph_component_size_min_threshold = 100
+
             }
         }
 

--- a/tests/default_pna.nf.test.snap
+++ b/tests/default_pna.nf.test.snap
@@ -7,6 +7,7 @@
                 "pipeline_info/nf_core_pixelator_software_mqc_versions.yml",
                 "pipeline_info/nf_core_pixelator_software_versions.yml",
                 "pixelator",
+                "pixelator/PNA055_Sample07_filtered_S7.pxl",
                 "pixelator/amplicon",
                 "pixelator/amplicon/PNA055_Sample07_filtered_S7.amplicon.fq.zst",
                 "pixelator/amplicon/PNA055_Sample07_filtered_S7.meta.json",
@@ -38,17 +39,17 @@
                 "pixelator/graph/PNA055_Sample07_filtered_S7.report.json",
                 "pixelator/layout",
                 "pixelator/layout/PNA055_Sample07_filtered_S7.meta.json",
-                "pixelator/layout/PNA055_Sample07_filtered_S7.pxl",
                 "pixelator/layout/PNA055_Sample07_filtered_S7.report.json",
                 "pixelator/logs",
-                "pixelator/logs/PNA055_Sample07_filtered_S7.demux.m1.part_000.pixelator-collapse.log",
-                "pixelator/logs/PNA055_Sample07_filtered_S7.demux.m2.part_000.pixelator-collapse.log",
-                "pixelator/logs/PNA055_Sample07_filtered_S7.pixelator-amplicon.log",
-                "pixelator/logs/PNA055_Sample07_filtered_S7.pixelator-analysis.log",
+                "pixelator/logs/PNA055_Sample07_filtered_S7",
                 "pixelator/logs/PNA055_Sample07_filtered_S7.pixelator-combine-collapse.log",
-                "pixelator/logs/PNA055_Sample07_filtered_S7.pixelator-demux.log",
-                "pixelator/logs/PNA055_Sample07_filtered_S7.pixelator-graph.log",
-                "pixelator/logs/PNA055_Sample07_filtered_S7.pixelator-layout.log"
+                "pixelator/logs/PNA055_Sample07_filtered_S7/PNA055_Sample07_filtered_S7.demux.m1.part_000.pixelator-collapse.log",
+                "pixelator/logs/PNA055_Sample07_filtered_S7/PNA055_Sample07_filtered_S7.demux.m2.part_000.pixelator-collapse.log",
+                "pixelator/logs/PNA055_Sample07_filtered_S7/PNA055_Sample07_filtered_S7.pixelator-amplicon.log",
+                "pixelator/logs/PNA055_Sample07_filtered_S7/PNA055_Sample07_filtered_S7.pixelator-analysis.log",
+                "pixelator/logs/PNA055_Sample07_filtered_S7/PNA055_Sample07_filtered_S7.pixelator-demux.log",
+                "pixelator/logs/PNA055_Sample07_filtered_S7/PNA055_Sample07_filtered_S7.pixelator-graph.log",
+                "pixelator/logs/PNA055_Sample07_filtered_S7/PNA055_Sample07_filtered_S7.pixelator-layout.log"
             ],
             [
                 
@@ -56,9 +57,9 @@
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "24.10.6"
+            "nextflow": "25.04.2"
         },
-        "timestamp": "2025-05-16T15:40:28.371338434"
+        "timestamp": "2025-05-22T18:03:14.833555344"
     },
     "Params: default": {
         "content": [
@@ -68,6 +69,7 @@
                 "pipeline_info/nf_core_pixelator_software_mqc_versions.yml",
                 "pipeline_info/nf_core_pixelator_software_versions.yml",
                 "pixelator",
+                "pixelator/PNA055_Sample07_filtered_S7.layout.pxl",
                 "pixelator/amplicon",
                 "pixelator/amplicon/PNA055_Sample07_filtered_S7.amplicon.fq.zst",
                 "pixelator/amplicon/PNA055_Sample07_filtered_S7.meta.json",
@@ -98,17 +100,17 @@
                 "pixelator/graph/PNA055_Sample07_filtered_S7.meta.json",
                 "pixelator/graph/PNA055_Sample07_filtered_S7.report.json",
                 "pixelator/layout",
-                "pixelator/layout/PNA055_Sample07_filtered_S7.layout.pxl",
                 "pixelator/layout/PNA055_Sample07_filtered_S7.meta.json",
                 "pixelator/layout/PNA055_Sample07_filtered_S7.report.json",
                 "pixelator/logs",
-                "pixelator/logs/PNA055_Sample07_filtered_S7.pixelator-amplicon.log",
-                "pixelator/logs/PNA055_Sample07_filtered_S7.pixelator-analysis.log",
-                "pixelator/logs/PNA055_Sample07_filtered_S7.pixelator-collapse.log",
+                "pixelator/logs/PNA055_Sample07_filtered_S7",
                 "pixelator/logs/PNA055_Sample07_filtered_S7.pixelator-combine-collapse.log",
-                "pixelator/logs/PNA055_Sample07_filtered_S7.pixelator-demux.log",
-                "pixelator/logs/PNA055_Sample07_filtered_S7.pixelator-graph.log",
-                "pixelator/logs/PNA055_Sample07_filtered_S7.pixelator-layout.log"
+                "pixelator/logs/PNA055_Sample07_filtered_S7/PNA055_Sample07_filtered_S7.pixelator-amplicon.log",
+                "pixelator/logs/PNA055_Sample07_filtered_S7/PNA055_Sample07_filtered_S7.pixelator-analysis.log",
+                "pixelator/logs/PNA055_Sample07_filtered_S7/PNA055_Sample07_filtered_S7.pixelator-collapse.log",
+                "pixelator/logs/PNA055_Sample07_filtered_S7/PNA055_Sample07_filtered_S7.pixelator-demux.log",
+                "pixelator/logs/PNA055_Sample07_filtered_S7/PNA055_Sample07_filtered_S7.pixelator-graph.log",
+                "pixelator/logs/PNA055_Sample07_filtered_S7/PNA055_Sample07_filtered_S7.pixelator-layout.log"
             ],
             [
                 
@@ -116,8 +118,8 @@
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "24.10.6"
+            "nextflow": "25.04.2"
         },
-        "timestamp": "2025-05-15T14:51:44.009938682"
+        "timestamp": "2025-05-23T08:01:46.583381452"
     }
 }


### PR DESCRIPTION
The pna module configs were not loaded, hence non of the config in there was being applied.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/pixelator/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/pixelator _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
