### PR TITLE
switch layout process label to process_high

### DIFF
--- a/modules/local/pixelator/single-cell-pna/layout/main.nf
+++ b/modules/local/pixelator/single-cell-pna/layout/main.nf
@@ -1,6 +1,6 @@
 process PIXELATOR_PNA_LAYOUT {
     tag "${meta.id}"
-    label 'process_high_memory'
+    label 'process_high'
 
     // TODO: Add conda
     // conda "bioconda::pixelator=0.18.2"


### PR DESCRIPTION
Now that layout step uses less memory we can also allocate less RAM and more CPUs to speed up the process.

