### PR TITLE
Make it possible to use relative path with `--input`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ the samplesheet, e.g. `proxiome-immuno-155-v1`.
 - Update panel files with new names for marker ids by @Aratz [#152](https://github.com/nf-core/pixelator/pull/152)
 - New panel file with FLAG add-on by @Aratz [#152](https://github.com/nf-core/pixelator/pull/152)
 - Template update for nf-core/tools v3.4.1 by @Aratz in [#151](https://github.com/nf-core/pixelator/pull/151)
+- `--input` now accepts relative paths by @Aratz [#153](https://github.com/nf-core/pixelator/pull/153)
 
 ### Software dependencies
 

--- a/subworkflows/local/pna/main.nf
+++ b/subworkflows/local/pna/main.nf
@@ -185,7 +185,7 @@ workflow PNA {
         .groupTuple(size: 2)
 
 
-    ch_input = Channel.of(params.input)
+    ch_input = Channel.fromPath(params.input)
 
     PNA_GENERATE_REPORTS(
         ch_input,


### PR DESCRIPTION
I've noticed pipeline runs fail in `EXPERIMENT_SUMMARY` when the input is a relative path to the samplesheet. This PR addresses this issue.

I haven't been able to write tests for this though, I've been trying to use a local file with `$projectDir` but it seems this is still an absolute path. If you have any ideas about how to test this better I'm all ears.

Fixes #154 

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] `CHANGELOG.md` is updated.
