### PR TITLE
Update pixelator to v0.22.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,13 @@ the samplesheet, e.g. `proxiome-immuno-155-v1`.
 - Template update for nf-core/tools v3.4.1 by @Aratz in [#151](https://github.com/nf-core/pixelator/pull/151)
 - `--input` now accepts relative paths by @Aratz [#153](https://github.com/nf-core/pixelator/pull/153)
 - Pass down memory limits in PNA demux and combine-collapse by @fbdtemme [#154](https://github.com/nf-core/pixelator/pull/154)
+- Fix custom panel usage by @Aratz [#156](https://github.com/nf-core/pixelator/pull/156)
 
 ### Software dependencies
 
 | Dependency  | Old version | New version |
 | ----------- | ----------- | ----------- |
-| `pixelator` | 0.21.4      | 0.22.0      |
+| `pixelator` | 0.21.4      | 0.22.1      |
 
 > [!NOTE]
 > Dependency has been **updated** if both old and new parameter information is present.

--- a/modules/local/collect_metadata/main.nf
+++ b/modules/local/collect_metadata/main.nf
@@ -5,8 +5,8 @@ process PIXELATOR_COLLECT_METADATA {
     // TODO: Add conda back
     // conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'quay.io/pixelgen-technologies/pixelator:0.22.0'
-        : 'quay.io/pixelgen-technologies/pixelator:0.22.0'}"
+        ? 'quay.io/pixelgen-technologies/pixelator:0.22.1'
+        : 'quay.io/pixelgen-technologies/pixelator:0.22.1'}"
 
     output:
     path "metadata.json", emit: metadata

--- a/modules/local/pixelator/list_options/main.nf
+++ b/modules/local/pixelator/list_options/main.nf
@@ -5,8 +5,8 @@ process PIXELATOR_LIST_OPTIONS {
     // TODO: Add conda back
     // conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'quay.io/pixelgen-technologies/pixelator:0.22.0'
-        : 'quay.io/pixelgen-technologies/pixelator:0.22.0'}"
+        ? 'quay.io/pixelgen-technologies/pixelator:0.22.1'
+        : 'quay.io/pixelgen-technologies/pixelator:0.22.1'}"
 
     output:
     path "design_options.txt", emit: designs

--- a/modules/local/pixelator/single-cell-mpx/amplicon/main.nf
+++ b/modules/local/pixelator/single-cell-mpx/amplicon/main.nf
@@ -6,8 +6,8 @@ process PIXELATOR_AMPLICON {
     // TODO: Add conda back
     // conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'quay.io/pixelgen-technologies/pixelator:0.22.0'
-        : 'quay.io/pixelgen-technologies/pixelator:0.22.0'}"
+        ? 'quay.io/pixelgen-technologies/pixelator:0.22.1'
+        : 'quay.io/pixelgen-technologies/pixelator:0.22.1'}"
 
     input:
     tuple val(meta), path(reads)

--- a/modules/local/pixelator/single-cell-mpx/amplicon/tests/main.nf.test.snap
+++ b/modules/local/pixelator/single-cell-mpx/amplicon/tests/main.nf.test.snap
@@ -89,7 +89,7 @@
                     ]
                 ],
                 "4": [
-                    "versions.yml:md5,c9d6b4390edb59e11117b79038d30405"
+                    "versions.yml:md5,60a7a0bbc070d248db9f89ab0972c46e"
                 ],
                 "log": [
                     [
@@ -136,7 +136,7 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,c9d6b4390edb59e11117b79038d30405"
+                    "versions.yml:md5,60a7a0bbc070d248db9f89ab0972c46e"
                 ]
             }
         ],
@@ -144,6 +144,6 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.0"
         },
-        "timestamp": "2025-10-24T10:57:55.763684577"
+        "timestamp": "2025-10-31T13:29:04.145467489"
     }
 }

--- a/modules/local/pixelator/single-cell-mpx/analysis/main.nf
+++ b/modules/local/pixelator/single-cell-mpx/analysis/main.nf
@@ -5,8 +5,8 @@ process PIXELATOR_ANALYSIS {
     // TODO: Add conda back
     // conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'quay.io/pixelgen-technologies/pixelator:0.22.0'
-        : 'quay.io/pixelgen-technologies/pixelator:0.22.0'}"
+        ? 'quay.io/pixelgen-technologies/pixelator:0.22.1'
+        : 'quay.io/pixelgen-technologies/pixelator:0.22.1'}"
 
     input:
     tuple val(meta), path(data)

--- a/modules/local/pixelator/single-cell-mpx/analysis/tests/main.nf.test.snap
+++ b/modules/local/pixelator/single-cell-mpx/analysis/tests/main.nf.test.snap
@@ -62,7 +62,7 @@
                     ]
                 ],
                 "5": [
-                    "versions.yml:md5,c78b27b727fe716a3a717467a1c3a135"
+                    "versions.yml:md5,294239a503f1320c924038c6554443a2"
                 ],
                 "all_results": [
                     [
@@ -124,7 +124,7 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,c78b27b727fe716a3a717467a1c3a135"
+                    "versions.yml:md5,294239a503f1320c924038c6554443a2"
                 ]
             }
         ],
@@ -132,6 +132,6 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.0"
         },
-        "timestamp": "2025-10-24T10:58:16.481187892"
+        "timestamp": "2025-10-31T13:29:29.629481535"
     }
 }

--- a/modules/local/pixelator/single-cell-mpx/annotate/main.nf
+++ b/modules/local/pixelator/single-cell-mpx/annotate/main.nf
@@ -5,8 +5,8 @@ process PIXELATOR_ANNOTATE {
     // TODO: Add conda back
     // conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'quay.io/pixelgen-technologies/pixelator:0.22.0'
-        : 'quay.io/pixelgen-technologies/pixelator:0.22.0'}"
+        ? 'quay.io/pixelgen-technologies/pixelator:0.22.1'
+        : 'quay.io/pixelgen-technologies/pixelator:0.22.1'}"
 
     input:
     tuple val(meta), path(dataset), path(panel_file), val(panel)

--- a/modules/local/pixelator/single-cell-mpx/annotate/tests/main.nf.test.snap
+++ b/modules/local/pixelator/single-cell-mpx/annotate/tests/main.nf.test.snap
@@ -1,13 +1,13 @@
 {
     "pxl": {
         "content": [
-            "metadata.json:md5,338091b8ff27462becd5ed06d90f5940"
+            "metadata.json:md5,82b35492f5e5067481c04c8612f466ee"
         ],
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.0"
         },
-        "timestamp": "2025-10-24T10:59:18.912768269"
+        "timestamp": "2025-10-31T13:30:45.331289297"
     },
     "Test MPX annotate - stub": {
         "content": [
@@ -72,7 +72,7 @@
                     ]
                 ],
                 "5": [
-                    "versions.yml:md5,d00bd722b0a184642e7b085a59a4311b"
+                    "versions.yml:md5,f96c065a146a6d0667467f30beb8092b"
                 ],
                 "all_results": [
                     [
@@ -134,7 +134,7 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,d00bd722b0a184642e7b085a59a4311b"
+                    "versions.yml:md5,f96c065a146a6d0667467f30beb8092b"
                 ]
             }
         ],
@@ -142,6 +142,6 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.0"
         },
-        "timestamp": "2025-10-24T10:58:57.805739546"
+        "timestamp": "2025-10-31T13:30:22.30561325"
     }
 }

--- a/modules/local/pixelator/single-cell-mpx/collapse/main.nf
+++ b/modules/local/pixelator/single-cell-mpx/collapse/main.nf
@@ -6,8 +6,8 @@ process PIXELATOR_COLLAPSE {
     // TODO: Add conda back
     // conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'quay.io/pixelgen-technologies/pixelator:0.22.0'
-        : 'quay.io/pixelgen-technologies/pixelator:0.22.0'}"
+        ? 'quay.io/pixelgen-technologies/pixelator:0.22.1'
+        : 'quay.io/pixelgen-technologies/pixelator:0.22.1'}"
 
     input:
     tuple val(meta), path(reads), path(panel_file), val(panel)

--- a/modules/local/pixelator/single-cell-mpx/collapse/tests/main.nf.test.snap
+++ b/modules/local/pixelator/single-cell-mpx/collapse/tests/main.nf.test.snap
@@ -89,7 +89,7 @@
                     ]
                 ],
                 "4": [
-                    "versions.yml:md5,4d34b00e5ce4a3cbb2a6187daf9b8163"
+                    "versions.yml:md5,29fb76a9bb02ad5d3c0fac614e6a6b58"
                 ],
                 "collapsed": [
                     [
@@ -136,7 +136,7 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,4d34b00e5ce4a3cbb2a6187daf9b8163"
+                    "versions.yml:md5,29fb76a9bb02ad5d3c0fac614e6a6b58"
                 ]
             }
         ],
@@ -144,6 +144,6 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.0"
         },
-        "timestamp": "2025-10-24T10:59:27.190142092"
+        "timestamp": "2025-10-31T13:30:54.378739049"
     }
 }

--- a/modules/local/pixelator/single-cell-mpx/demux/main.nf
+++ b/modules/local/pixelator/single-cell-mpx/demux/main.nf
@@ -5,8 +5,8 @@ process PIXELATOR_DEMUX {
     // TODO: Add conda back
     // conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'quay.io/pixelgen-technologies/pixelator:0.22.0'
-        : 'quay.io/pixelgen-technologies/pixelator:0.22.0'}"
+        ? 'quay.io/pixelgen-technologies/pixelator:0.22.1'
+        : 'quay.io/pixelgen-technologies/pixelator:0.22.1'}"
 
     input:
     tuple val(meta), path(reads), path(panel_file), val(panel)

--- a/modules/local/pixelator/single-cell-mpx/demux/tests/main.nf.test.snap
+++ b/modules/local/pixelator/single-cell-mpx/demux/tests/main.nf.test.snap
@@ -58,7 +58,7 @@
                     ]
                 ],
                 "5": [
-                    "versions.yml:md5,bf71a33af9d07af6d13463b40ac6521f"
+                    "versions.yml:md5,e046bd710e4ef6dc9a7fffa8edd9d26e"
                 ],
                 "failed": [
                     [
@@ -116,7 +116,7 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,bf71a33af9d07af6d13463b40ac6521f"
+                    "versions.yml:md5,e046bd710e4ef6dc9a7fffa8edd9d26e"
                 ]
             }
         ],
@@ -124,7 +124,7 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.0"
         },
-        "timestamp": "2025-10-24T10:59:50.087524376"
+        "timestamp": "2025-10-31T13:31:18.820549773"
     },
     "Test MPX demux - SCSP v1 | Immunology-I": {
         "content": [
@@ -243,14 +243,14 @@
                 ]
             ],
             [
-                "versions.yml:md5,bf71a33af9d07af6d13463b40ac6521f"
+                "versions.yml:md5,e046bd710e4ef6dc9a7fffa8edd9d26e"
             ]
         ],
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.0"
         },
-        "timestamp": "2025-10-24T11:00:06.552973036"
+        "timestamp": "2025-10-31T13:31:36.148658933"
     },
     "report_json": {
         "content": [
@@ -260,7 +260,7 @@
                     0,
                     3
                 ],
-                "cutadapt_version": "5.1",
+                "cutadapt_version": "5.2",
                 "python_version": "3.12.12",
                 "cores": 2,
                 "input": {
@@ -2870,6 +2870,6 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.0"
         },
-        "timestamp": "2025-10-24T11:00:06.924927722"
+        "timestamp": "2025-10-31T13:31:36.52595872"
     }
 }

--- a/modules/local/pixelator/single-cell-mpx/graph/main.nf
+++ b/modules/local/pixelator/single-cell-mpx/graph/main.nf
@@ -5,8 +5,8 @@ process PIXELATOR_GRAPH {
     // TODO: Add conda back
     // conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'quay.io/pixelgen-technologies/pixelator:0.22.0'
-        : 'quay.io/pixelgen-technologies/pixelator:0.22.0'}"
+        ? 'quay.io/pixelgen-technologies/pixelator:0.22.1'
+        : 'quay.io/pixelgen-technologies/pixelator:0.22.1'}"
 
     input:
     tuple val(meta), path(edge_list)

--- a/modules/local/pixelator/single-cell-mpx/graph/tests/main.nf.test.snap
+++ b/modules/local/pixelator/single-cell-mpx/graph/tests/main.nf.test.snap
@@ -104,7 +104,7 @@
                     ]
                 ],
                 "5": [
-                    "versions.yml:md5,c172c746b173c4b6870c81d6bf99a0dc"
+                    "versions.yml:md5,2ce348f9f12c9cff1a7a9a2e2e0c8fbe"
                 ],
                 "all_results": [
                     [
@@ -166,7 +166,7 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,c172c746b173c4b6870c81d6bf99a0dc"
+                    "versions.yml:md5,2ce348f9f12c9cff1a7a9a2e2e0c8fbe"
                 ]
             }
         ],
@@ -174,6 +174,6 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.0"
         },
-        "timestamp": "2025-10-24T11:00:15.504928444"
+        "timestamp": "2025-10-31T13:31:45.557081702"
     }
 }

--- a/modules/local/pixelator/single-cell-mpx/layout/main.nf
+++ b/modules/local/pixelator/single-cell-mpx/layout/main.nf
@@ -5,8 +5,8 @@ process PIXELATOR_LAYOUT {
     // TODO: Add conda back
     // conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'quay.io/pixelgen-technologies/pixelator:0.22.0'
-        : 'quay.io/pixelgen-technologies/pixelator:0.22.0'}"
+        ? 'quay.io/pixelgen-technologies/pixelator:0.22.1'
+        : 'quay.io/pixelgen-technologies/pixelator:0.22.1'}"
 
     input:
     tuple val(meta), path(data)

--- a/modules/local/pixelator/single-cell-mpx/layout/tests/main.nf.test.snap
+++ b/modules/local/pixelator/single-cell-mpx/layout/tests/main.nf.test.snap
@@ -103,7 +103,7 @@
                     ]
                 ],
                 "5": [
-                    "versions.yml:md5,91b29ff139206fde1559b136d9fcdbc4"
+                    "versions.yml:md5,9e7c3c3241e18444340a6dfe143b5eab"
                 ],
                 "all_results": [
                     [
@@ -165,7 +165,7 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,91b29ff139206fde1559b136d9fcdbc4"
+                    "versions.yml:md5,9e7c3c3241e18444340a6dfe143b5eab"
                 ]
             }
         ],
@@ -173,6 +173,6 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.0"
         },
-        "timestamp": "2025-10-24T11:00:35.465695685"
+        "timestamp": "2025-10-31T13:32:07.926631199"
     }
 }

--- a/modules/local/pixelator/single-cell-mpx/qc/main.nf
+++ b/modules/local/pixelator/single-cell-mpx/qc/main.nf
@@ -5,8 +5,8 @@ process PIXELATOR_QC {
     // TODO: Add conda back
     // conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'quay.io/pixelgen-technologies/pixelator:0.22.0'
-        : 'quay.io/pixelgen-technologies/pixelator:0.22.0'}"
+        ? 'quay.io/pixelgen-technologies/pixelator:0.22.1'
+        : 'quay.io/pixelgen-technologies/pixelator:0.22.1'}"
 
     input:
     tuple val(meta), path(reads)

--- a/modules/local/pixelator/single-cell-mpx/qc/tests/main.nf.test.snap
+++ b/modules/local/pixelator/single-cell-mpx/qc/tests/main.nf.test.snap
@@ -97,7 +97,7 @@
                     ]
                 ],
                 "16": [
-                    "versions.yml:md5,51afc282bd02d2be8da62e2f6b8c47a4"
+                    "versions.yml:md5,2c93dd7d724759bc9c3e339548090edb"
                 ],
                 "2": [
                     [
@@ -382,7 +382,7 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,51afc282bd02d2be8da62e2f6b8c47a4"
+                    "versions.yml:md5,2c93dd7d724759bc9c3e339548090edb"
                 ]
             }
         ],
@@ -390,6 +390,6 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.0"
         },
-        "timestamp": "2025-10-24T11:01:01.444083676"
+        "timestamp": "2025-10-31T13:32:35.75886849"
     }
 }

--- a/modules/local/pixelator/single-cell-mpx/report/main.nf
+++ b/modules/local/pixelator/single-cell-mpx/report/main.nf
@@ -5,8 +5,8 @@ process PIXELATOR_REPORT {
     // TODO: Add conda back
     // conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'quay.io/pixelgen-technologies/pixelator:0.22.0'
-        : 'quay.io/pixelgen-technologies/pixelator:0.22.0'}"
+        ? 'quay.io/pixelgen-technologies/pixelator:0.22.1'
+        : 'quay.io/pixelgen-technologies/pixelator:0.22.1'}"
 
     input:
     tuple val(meta), path(panel_file), val(panel)

--- a/modules/local/pixelator/single-cell-mpx/report/tests/main.nf.test.snap
+++ b/modules/local/pixelator/single-cell-mpx/report/tests/main.nf.test.snap
@@ -25,7 +25,7 @@
                     ]
                 ],
                 "2": [
-                    "versions.yml:md5,92ad57ba815f3d3bac15a822135026b5"
+                    "versions.yml:md5,2a9fd8a87a02fbd4b9c0d087aee3643b"
                 ],
                 "log": [
                     [
@@ -50,7 +50,7 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,92ad57ba815f3d3bac15a822135026b5"
+                    "versions.yml:md5,2a9fd8a87a02fbd4b9c0d087aee3643b"
                 ]
             }
         ],
@@ -58,19 +58,19 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.0"
         },
-        "timestamp": "2025-10-24T11:01:38.932990995"
+        "timestamp": "2025-10-31T13:33:10.23957407"
     },
     "Test MPX report - SCSP v1 | Immunology-I": {
         "content": [
             null,
             [
-                "versions.yml:md5,92ad57ba815f3d3bac15a822135026b5"
+                "versions.yml:md5,2a9fd8a87a02fbd4b9c0d087aee3643b"
             ]
         ],
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.0"
         },
-        "timestamp": "2025-10-24T11:01:54.720555963"
+        "timestamp": "2025-10-31T13:33:24.598297308"
     }
 }

--- a/modules/local/pixelator/single-cell-pna/amplicon/main.nf
+++ b/modules/local/pixelator/single-cell-pna/amplicon/main.nf
@@ -5,8 +5,8 @@ process PIXELATOR_PNA_AMPLICON {
     // TODO: Add conda
     // conda "bioconda::pixelator=0.18.2"
     container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'quay.io/pixelgen-technologies/pixelator:0.22.0'
-        : 'quay.io/pixelgen-technologies/pixelator:0.22.0'}"
+        ? 'quay.io/pixelgen-technologies/pixelator:0.22.1'
+        : 'quay.io/pixelgen-technologies/pixelator:0.22.1'}"
 
     input:
     tuple val(meta), path(reads, arity: '1..*')

--- a/modules/local/pixelator/single-cell-pna/amplicon/tests/main.nf.test.snap
+++ b/modules/local/pixelator/single-cell-pna/amplicon/tests/main.nf.test.snap
@@ -9,15 +9,15 @@
                         "panel": "proxiome-immuno-155",
                         "technology": "pna"
                     },
-                    "PNA055_Sample07_filtered_S7.amplicon.fq.zst:md5,460f0dd9af7c5ebec8bcad76e3964b7d"
+                    "PNA055_Sample07_filtered_S7.amplicon.fq.zst:md5,719f000b22bd9af91ffce0ec3439be83"
                 ]
             ]
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.2"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.0"
         },
-        "timestamp": "2025-06-27T08:26:22.987687656"
+        "timestamp": "2025-10-31T13:33:46.990532595"
     },
     "report_json": {
         "content": [
@@ -29,15 +29,15 @@
                         "panel": "proxiome-immuno-155",
                         "technology": "pna"
                     },
-                    "PNA055_Sample07_filtered_S7.report.json:md5,ae3608057ebf0eceaae5b3c0efa8320b"
+                    "PNA055_Sample07_filtered_S7.report.json:md5,57884d3982d6b3b9827ea89001bfcfb0"
                 ]
             ]
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.2"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.0"
         },
-        "timestamp": "2025-05-22T17:25:27.100151311"
+        "timestamp": "2025-10-31T13:33:47.054676031"
     },
     "metadata_json": {
         "content": [

--- a/modules/local/pixelator/single-cell-pna/analysis/main.nf
+++ b/modules/local/pixelator/single-cell-pna/analysis/main.nf
@@ -6,8 +6,8 @@ process PIXELATOR_PNA_ANALYSIS {
     // conda "bioconda::pixelator=0.18.2"
 
     container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'quay.io/pixelgen-technologies/pixelator:0.22.0'
-        : 'quay.io/pixelgen-technologies/pixelator:0.22.0'}"
+        ? 'quay.io/pixelgen-technologies/pixelator:0.22.1'
+        : 'quay.io/pixelgen-technologies/pixelator:0.22.1'}"
 
     input:
     tuple val(meta), path(data)

--- a/modules/local/pixelator/single-cell-pna/analysis/tests/main.nf.test.snap
+++ b/modules/local/pixelator/single-cell-pna/analysis/tests/main.nf.test.snap
@@ -2,14 +2,14 @@
     "versions": {
         "content": [
             [
-                "versions.yml:md5,2d2c574c000c8e5f1503eb8a8cada90b"
+                "versions.yml:md5,ca60633f194ab0e5f36e097c4b1e0569"
             ]
         ],
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.0"
         },
-        "timestamp": "2025-10-24T11:03:22.927316873"
+        "timestamp": "2025-10-31T13:34:59.516988966"
     },
     "report_json": {
         "content": [

--- a/modules/local/pixelator/single-cell-pna/collapse/main.nf
+++ b/modules/local/pixelator/single-cell-pna/collapse/main.nf
@@ -7,8 +7,8 @@ process PIXELATOR_PNA_COLLAPSE {
     // TODO: Add conda
     // conda "bioconda::pixelator=0.18.2"
     container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'quay.io/pixelgen-technologies/pixelator:0.22.0'
-        : 'quay.io/pixelgen-technologies/pixelator:0.22.0'}"
+        ? 'quay.io/pixelgen-technologies/pixelator:0.22.1'
+        : 'quay.io/pixelgen-technologies/pixelator:0.22.1'}"
 
     input:
     tuple val(meta), path(reads), path(panel_file), val(panel), val(design)

--- a/modules/local/pixelator/single-cell-pna/collapse/tests/main.nf.test.snap
+++ b/modules/local/pixelator/single-cell-pna/collapse/tests/main.nf.test.snap
@@ -59,26 +59,26 @@
     "versions": {
         "content": [
             [
-                "versions.yml:md5,3cc3fa913e0d88ba5159bd00c9fed621"
+                "versions.yml:md5,462d418a2ce35a965e966e432ae04ba1"
             ]
         ],
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.0"
         },
-        "timestamp": "2025-10-24T11:03:38.325878963"
+        "timestamp": "2025-10-31T13:35:15.724385618"
     },
     "multi_versions": {
         "content": [
             [
-                "versions.yml:md5,3cc3fa913e0d88ba5159bd00c9fed621"
+                "versions.yml:md5,462d418a2ce35a965e966e432ae04ba1"
             ]
         ],
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.0"
         },
-        "timestamp": "2025-10-24T11:03:55.38706619"
+        "timestamp": "2025-10-31T13:35:33.889709909"
     },
     "header": {
         "content": [

--- a/modules/local/pixelator/single-cell-pna/combine_collapse/main.nf
+++ b/modules/local/pixelator/single-cell-pna/combine_collapse/main.nf
@@ -6,8 +6,8 @@ process PIXELATOR_PNA_COMBINE_COLLAPSE {
     // conda "bioconda::pixelator=0.18.2"
 
     container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'quay.io/pixelgen-technologies/pixelator:0.22.0'
-        : 'quay.io/pixelgen-technologies/pixelator:0.22.0'}"
+        ? 'quay.io/pixelgen-technologies/pixelator:0.22.1'
+        : 'quay.io/pixelgen-technologies/pixelator:0.22.1'}"
 
     input:
     tuple val(meta), path(parquet_files, stageAs: "parquet/*"), path(json_report_files, stageAs: "reports/*")

--- a/modules/local/pixelator/single-cell-pna/combine_collapse/tests/main.nf.test.snap
+++ b/modules/local/pixelator/single-cell-pna/combine_collapse/tests/main.nf.test.snap
@@ -13,23 +13,23 @@
                 ]
             ],
             [
-                "versions.yml:md5,09b47145a7333736cd2aacdec779d79b"
+                "versions.yml:md5,fdd993fc8aaed7c5185c5d6ab77e479f"
             ]
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.6"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.0"
         },
-        "timestamp": "2025-10-29T09:53:01.528309376"
+        "timestamp": "2025-10-31T14:31:30.520706186"
     },
     "meta_json": {
         "content": [
             "{cli={command=pixelator single-cell-pna combine-collapse, options={--parquet=[parquet/PNA055_Sample07_filtered_S7.collapse.m1.part_000.parquet, parquet/PNA055_Sample07_filtered_S7.collapse.m1.part_001.parquet, parquet/PNA055_Sample07_filtered_S7.collapse.m2.part_000.parquet, parquet/PNA055_Sample07_filtered_S7.collapse.m2.part_001.parquet], --report=[reports/PNA055_Sample07_filtered_S7.collapse.m1.part_000.report.json, reports/PNA055_Sample07_filtered_S7.collapse.m1.part_001.report.json, reports/PNA055_Sample07_filtered_S7.collapse.m2.part_000.report.json, reports/PNA055_Sample07_filtered_S7.collapse.m2.part_001.report.json], --parquet-pattern=null, --report-pattern=null, --output=.}}}"
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.6"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.0"
         },
-        "timestamp": "2025-10-29T09:53:01.500262602"
+        "timestamp": "2025-10-31T14:31:30.509966414"
     }
 }

--- a/modules/local/pixelator/single-cell-pna/demux/main.nf
+++ b/modules/local/pixelator/single-cell-pna/demux/main.nf
@@ -6,8 +6,8 @@ process PIXELATOR_PNA_DEMUX {
     // conda "bioconda::pixelator=0.18.2"
 
     container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'quay.io/pixelgen-technologies/pixelator:0.22.0'
-        : 'quay.io/pixelgen-technologies/pixelator:0.22.0'}"
+        ? 'quay.io/pixelgen-technologies/pixelator:0.22.1'
+        : 'quay.io/pixelgen-technologies/pixelator:0.22.1'}"
 
     input:
     tuple val(meta), path(reads), path(panel_file), val(panel), val(design)

--- a/modules/local/pixelator/single-cell-pna/demux/tests/main.nf.test.snap
+++ b/modules/local/pixelator/single-cell-pna/demux/tests/main.nf.test.snap
@@ -4,10 +4,10 @@
             "{cli={command=pixelator single-cell-pna demux, options={--mismatches=1, --output-chunk-reads=40000, --output-max-chunks=8, --strategy=independent, --design=pna-2, --panel=proxiome-immuno-155, --output=.}}}"
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.6"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.0"
         },
-        "timestamp": "2025-10-29T09:53:59.371397444"
+        "timestamp": "2025-10-31T14:32:56.130489586"
     },
     "multi_passed": {
         "content": [
@@ -19,7 +19,7 @@
                         "panel": "proxiome-immuno-155",
                         "technology": "pna"
                     },
-                    "PNA055_Sample07_filtered_S7.demux.passed.fq.zst:md5,bffd9af4224cb63d02a243b7297d9a20"
+                    "PNA055_Sample07_filtered_S7.demux.passed.fq.zst:md5,d6519e42f6bdea8b443e4d9ab20e85bd"
                 ]
             ]
         ],
@@ -27,7 +27,7 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.0"
         },
-        "timestamp": "2025-10-24T11:05:05.618019276"
+        "timestamp": "2025-10-31T14:32:55.848329932"
     },
     "report_json": {
         "content": [
@@ -39,10 +39,10 @@
             ]
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.6"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.0"
         },
-        "timestamp": "2025-10-29T09:44:08.052610022"
+        "timestamp": "2025-10-31T14:32:12.020890319"
     },
     "multi_failed": {
         "content": [
@@ -54,7 +54,7 @@
                         "panel": "proxiome-immuno-155",
                         "technology": "pna"
                     },
-                    "PNA055_Sample07_filtered_S7.demux.failed.fq.zst:md5,44e8bee4f2f2bfbb2edcec1217b3ebc5"
+                    "PNA055_Sample07_filtered_S7.demux.failed.fq.zst:md5,c5dbf4ee3c3ace5c3af6cff3eda2d9da"
                 ]
             ]
         ],
@@ -62,7 +62,7 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.0"
         },
-        "timestamp": "2025-10-24T11:05:05.73169804"
+        "timestamp": "2025-10-31T14:32:55.914745339"
     },
     "passed": {
         "content": [
@@ -74,7 +74,7 @@
                         "panel": "proxiome-immuno-155",
                         "technology": "pna"
                     },
-                    "PNA055_Sample07_filtered_S7.demux.passed.fq.zst:md5,bffd9af4224cb63d02a243b7297d9a20"
+                    "PNA055_Sample07_filtered_S7.demux.passed.fq.zst:md5,d6519e42f6bdea8b443e4d9ab20e85bd"
                 ]
             ]
         ],
@@ -82,7 +82,7 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.0"
         },
-        "timestamp": "2025-10-24T11:04:38.519824084"
+        "timestamp": "2025-10-31T14:32:11.940422055"
     },
     "failed": {
         "content": [
@@ -94,7 +94,7 @@
                         "panel": "proxiome-immuno-155",
                         "technology": "pna"
                     },
-                    "PNA055_Sample07_filtered_S7.demux.failed.fq.zst:md5,44e8bee4f2f2bfbb2edcec1217b3ebc5"
+                    "PNA055_Sample07_filtered_S7.demux.failed.fq.zst:md5,c5dbf4ee3c3ace5c3af6cff3eda2d9da"
                 ]
             ]
         ],
@@ -102,7 +102,7 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.0"
         },
-        "timestamp": "2025-10-24T11:04:38.605523473"
+        "timestamp": "2025-10-31T14:32:11.944615428"
     },
     "multi_report_json": {
         "content": [
@@ -114,19 +114,19 @@
             ]
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.6"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.0"
         },
-        "timestamp": "2025-10-29T09:53:59.351576099"
+        "timestamp": "2025-10-31T14:32:56.031891664"
     },
     "meta_json": {
         "content": [
             "{cli={command=pixelator single-cell-pna demux, options={--mismatches=1, --output-chunk-reads=50000000, --output-max-chunks=8, --strategy=independent, --design=pna-2, --panel=proxiome-immuno-155, --output=.}}}"
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.6"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.0"
         },
-        "timestamp": "2025-10-29T09:44:08.093627475"
+        "timestamp": "2025-10-31T14:32:12.08634667"
     }
 }

--- a/modules/local/pixelator/single-cell-pna/denoise/main.nf
+++ b/modules/local/pixelator/single-cell-pna/denoise/main.nf
@@ -6,8 +6,8 @@ process PIXELATOR_PNA_DENOISE {
     // conda "bioconda::pixelator=0.18.2"
 
     container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'quay.io/pixelgen-technologies/pixelator:0.22.0'
-        : 'quay.io/pixelgen-technologies/pixelator:0.22.0'}"
+        ? 'quay.io/pixelgen-technologies/pixelator:0.22.1'
+        : 'quay.io/pixelgen-technologies/pixelator:0.22.1'}"
 
     input:
     tuple val(meta), path(data)

--- a/modules/local/pixelator/single-cell-pna/denoise/tests/main.nf.test.snap
+++ b/modules/local/pixelator/single-cell-pna/denoise/tests/main.nf.test.snap
@@ -2,14 +2,14 @@
     "versions": {
         "content": [
             [
-                "versions.yml:md5,2161f89c6162a6719cfebebbd8cce972"
+                "versions.yml:md5,29155ee86d4024081bbb00a745aee4c7"
             ]
         ],
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.0"
         },
-        "timestamp": "2025-10-24T11:05:24.34319073"
+        "timestamp": "2025-10-31T13:37:34.487295571"
     },
     "report_json": {
         "content": [

--- a/modules/local/pixelator/single-cell-pna/graph/main.nf
+++ b/modules/local/pixelator/single-cell-pna/graph/main.nf
@@ -4,8 +4,8 @@ process PIXELATOR_PNA_GRAPH {
     label 'process_long'
 
     container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'quay.io/pixelgen-technologies/pixelator:0.22.0'
-        : 'quay.io/pixelgen-technologies/pixelator:0.22.0'}"
+        ? 'quay.io/pixelgen-technologies/pixelator:0.22.1'
+        : 'quay.io/pixelgen-technologies/pixelator:0.22.1'}"
 
     input:
     tuple val(meta), path(edge_list), path(panel_file), val(panel)

--- a/modules/local/pixelator/single-cell-pna/graph/tests/main.nf.test.snap
+++ b/modules/local/pixelator/single-cell-pna/graph/tests/main.nf.test.snap
@@ -2,14 +2,14 @@
     "versions": {
         "content": [
             [
-                "versions.yml:md5,fe260923847a598b66ea0fdff605eef8"
+                "versions.yml:md5,9eb7bc97c868543db572401d7f6212fa"
             ]
         ],
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.0"
         },
-        "timestamp": "2025-10-24T11:05:37.679759356"
+        "timestamp": "2025-10-31T13:37:48.075295722"
     },
     "report_json": {
         "content": [

--- a/modules/local/pixelator/single-cell-pna/layout/main.nf
+++ b/modules/local/pixelator/single-cell-pna/layout/main.nf
@@ -5,8 +5,8 @@ process PIXELATOR_PNA_LAYOUT {
     // TODO: Add conda
     // conda "bioconda::pixelator=0.18.2"
     container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'quay.io/pixelgen-technologies/pixelator:0.22.0'
-        : 'quay.io/pixelgen-technologies/pixelator:0.22.0'}"
+        ? 'quay.io/pixelgen-technologies/pixelator:0.22.1'
+        : 'quay.io/pixelgen-technologies/pixelator:0.22.1'}"
 
     input:
     tuple val(meta), path(data)

--- a/modules/local/pixelator/single-cell-pna/report/main.nf
+++ b/modules/local/pixelator/single-cell-pna/report/main.nf
@@ -6,8 +6,8 @@ process PIXELATOR_PNA_REPORT {
     // TODO: Add conda
     // conda "bioconda::pixelator=0.18.2"
     container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'quay.io/pixelgen-technologies/pixelator:0.22.0'
-        : 'quay.io/pixelgen-technologies/pixelator:0.22.0'}"
+        ? 'quay.io/pixelgen-technologies/pixelator:0.22.1'
+        : 'quay.io/pixelgen-technologies/pixelator:0.22.1'}"
 
     input:
     tuple (

--- a/modules/local/pixelator/single-cell-pna/report/tests/main.nf.test.snap
+++ b/modules/local/pixelator/single-cell-pna/report/tests/main.nf.test.snap
@@ -2,13 +2,13 @@
     "versions": {
         "content": [
             [
-                "versions.yml:md5,ff45e5a8c51becc13917cd2b8a91cc36"
+                "versions.yml:md5,c3116fd7efdf36b9bb772996a6abfbdd"
             ]
         ],
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.0"
         },
-        "timestamp": "2025-10-24T11:06:02.51635063"
+        "timestamp": "2025-10-31T13:38:13.165882875"
     }
 }

--- a/subworkflows/local/generate_reports/tests/main.nf.test.snap
+++ b/subworkflows/local/generate_reports/tests/main.nf.test.snap
@@ -2,14 +2,14 @@
     "Test MPX Generate reports - SCSP v1 | Immunology-I": {
         "content": [
             [
-                "versions.yml:md5,76408716b135c967a691f93b963fa0b8"
+                "versions.yml:md5,a7151b6c0424376e5821c074ad03bdf4"
             ]
         ],
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.0"
         },
-        "timestamp": "2025-10-24T11:06:30.470310408"
+        "timestamp": "2025-10-31T13:38:44.106466875"
     },
     "Test MPX Generate reports - stub": {
         "content": [
@@ -26,7 +26,7 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,76408716b135c967a691f93b963fa0b8"
+                    "versions.yml:md5,a7151b6c0424376e5821c074ad03bdf4"
                 ],
                 "pixelator_reports": [
                     [
@@ -40,7 +40,7 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,76408716b135c967a691f93b963fa0b8"
+                    "versions.yml:md5,a7151b6c0424376e5821c074ad03bdf4"
                 ]
             }
         ],
@@ -48,6 +48,6 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.0"
         },
-        "timestamp": "2025-10-24T11:06:15.375662204"
+        "timestamp": "2025-10-31T13:38:27.660723073"
     }
 }

--- a/subworkflows/local/pna/tests/main.nf.test.snap
+++ b/subworkflows/local/pna/tests/main.nf.test.snap
@@ -2,21 +2,21 @@
     "versions": {
         "content": [
             [
-                "versions.yml:md5,377db4d3b6ed52b3eb25e452d1437a92",
-                "versions.yml:md5,3a6e44e143b327eab09af83c6bf898b4",
-                "versions.yml:md5,47b123a925219eaa163bbfe4e8e7575f",
-                "versions.yml:md5,7f500ad0a501070b027eba4748f1afd4",
-                "versions.yml:md5,82a6d489845fad938d6def320e2b954c",
-                "versions.yml:md5,8a06b4ff3607c905ab724f360fa58e08",
-                "versions.yml:md5,98b8d8b0239ea4f914b14caa16e6c4d7",
-                "versions.yml:md5,b8e607141f495237ead8ff8af64da6df",
-                "versions.yml:md5,fdd91e6a50a655527240e5e4e5315032"
+                "versions.yml:md5,07827affe5e02f3bf5876bc6a143322b",
+                "versions.yml:md5,0eddaffb752d61e6f84fd9389503db06",
+                "versions.yml:md5,2a235d854b0de2c001022e3a0b75db36",
+                "versions.yml:md5,5979e7443d33df2bc1d5535048d69fe4",
+                "versions.yml:md5,5c82cefeb09e4e26929dc38721e5ce05",
+                "versions.yml:md5,6b2ef1c32dd32cd7793037872d8226bf",
+                "versions.yml:md5,90bb5dfe9c82b2e36ed0559d73de90bd",
+                "versions.yml:md5,ba050a673a094bc584a79090768b336b",
+                "versions.yml:md5,d885a07d6905ff5cf5fb2fd7c19a6cc1"
             ]
         ],
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.0"
         },
-        "timestamp": "2025-10-24T11:09:44.679671268"
+        "timestamp": "2025-10-31T13:42:12.626709109"
     }
 }

--- a/tests/default_mpx.nf.test.snap
+++ b/tests/default_mpx.nf.test.snap
@@ -63,31 +63,31 @@
             10,
             {
                 "PIXELATOR_AMPLICON": {
-                    "pixelator": "0.22.0"
+                    "pixelator": "0.22.1"
                 },
                 "PIXELATOR_ANALYSIS": {
-                    "pixelator": "0.22.0"
+                    "pixelator": "0.22.1"
                 },
                 "PIXELATOR_ANNOTATE": {
-                    "pixelator": "0.22.0"
+                    "pixelator": "0.22.1"
                 },
                 "PIXELATOR_COLLAPSE": {
-                    "pixelator": "0.22.0"
+                    "pixelator": "0.22.1"
                 },
                 "PIXELATOR_DEMUX": {
-                    "pixelator": "0.22.0"
+                    "pixelator": "0.22.1"
                 },
                 "PIXELATOR_GRAPH": {
-                    "pixelator": "0.22.0"
+                    "pixelator": "0.22.1"
                 },
                 "PIXELATOR_LAYOUT": {
-                    "pixelator": "0.22.0"
+                    "pixelator": "0.22.1"
                 },
                 "PIXELATOR_QC": {
-                    "pixelator": "0.22.0"
+                    "pixelator": "0.22.1"
                 },
                 "PIXELATOR_REPORT": {
-                    "pixelator": "0.22.0"
+                    "pixelator": "0.22.1"
                 },
                 "Workflow": {
                     "nf-core/pixelator": "v2.1.0"
@@ -147,6 +147,6 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.0"
         },
-        "timestamp": "2025-10-24T11:12:16.411901744"
+        "timestamp": "2025-10-31T13:44:51.479395756"
     }
 }

--- a/tests/default_pna.nf.test.snap
+++ b/tests/default_pna.nf.test.snap
@@ -63,31 +63,31 @@
             11,
             {
                 "PIXELATOR_PNA_AMPLICON": {
-                    "pixelator": "0.22.0"
+                    "pixelator": "0.22.1"
                 },
                 "PIXELATOR_PNA_ANALYSIS": {
-                    "pixelator": "0.22.0"
+                    "pixelator": "0.22.1"
                 },
                 "PIXELATOR_PNA_COLLAPSE": {
-                    "pixelator": "0.22.0"
+                    "pixelator": "0.22.1"
                 },
                 "PIXELATOR_PNA_COMBINE_COLLAPSE": {
-                    "pixelator": "0.22.0"
+                    "pixelator": "0.22.1"
                 },
                 "PIXELATOR_PNA_DEMUX": {
-                    "pixelator": "0.22.0"
+                    "pixelator": "0.22.1"
                 },
                 "PIXELATOR_PNA_DENOISE": {
-                    "pixelator": "0.22.0"
+                    "pixelator": "0.22.1"
                 },
                 "PIXELATOR_PNA_GRAPH": {
-                    "pixelator": "0.22.0"
+                    "pixelator": "0.22.1"
                 },
                 "PIXELATOR_PNA_LAYOUT": {
-                    "pixelator": "0.22.0"
+                    "pixelator": "0.22.1"
                 },
                 "PIXELATOR_PNA_REPORT": {
-                    "pixelator": "0.22.0"
+                    "pixelator": "0.22.1"
                 },
                 "Workflow": {
                     "nf-core/pixelator": "v2.1.0"
@@ -146,6 +146,6 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.0"
         },
-        "timestamp": "2025-10-24T11:16:23.129864994"
+        "timestamp": "2025-10-31T13:49:12.219881989"
     }
 }

--- a/tests/pna_es.nf.test
+++ b/tests/pna_es.nf.test
@@ -43,6 +43,43 @@ nextflow_pipeline {
         }
     }
 
+    test("custom panel") {
+
+        when {
+            params {
+
+                pipelines_testdata_base_path           = "https://raw.githubusercontent.com/nf-core/test-datasets/pixelator/"
+                input                                  = "$pipelines_testdata_base_path/samplesheet/pna/samplesheet_pna_es_custom_panel.csv"
+                input_basedir                          = "$pipelines_testdata_base_path/testdata/pna/"
+                outdir                                 = "$outputDir"
+
+                pna_graph_component_size_min_threshold = 100
+                skip_experiment_summary                = false
+            }
+        }
+
+        then {
+            // stable_name: All files + folders in ${params.outdir}/ with a stable name
+            def stable_name = getAllFilesFromDir(params.outdir, relative: true, includeDir: true, ignore: ['pipeline_info/*.{html,json,txt}'])
+            // stable_path: All files in ${params.outdir}/ with stable content
+            def stable_path = []
+
+            assertAll(
+                { assert workflow.success},
+                { assert snapshot(
+                    // Number of successful tasks
+                    workflow.trace.succeeded().size(),
+                    // pipeline versions.yml file for multiqc from which Nextflow version is removed because we tests pipelines on multiple Nextflow versions
+                    removeNextflowVersion("$outputDir/pipeline_info/nf_core_pixelator_software_mqc_versions.yml"),
+                    // All stable path name, with a relative path
+                    stable_name,
+                    // All files with stable contents
+                    stable_path
+                ).match() }
+            )
+        }
+    }
+
     test("small - stub") {
 
         options "-stub"

--- a/tests/pna_es.nf.test.snap
+++ b/tests/pna_es.nf.test.snap
@@ -7,31 +7,31 @@
                     "experiment-summary": "0.4.3"
                 },
                 "PIXELATOR_PNA_AMPLICON": {
-                    "pixelator": "0.22.0"
+                    "pixelator": "0.22.1"
                 },
                 "PIXELATOR_PNA_ANALYSIS": {
-                    "pixelator": "0.22.0"
+                    "pixelator": "0.22.1"
                 },
                 "PIXELATOR_PNA_COLLAPSE": {
-                    "pixelator": "0.22.0"
+                    "pixelator": "0.22.1"
                 },
                 "PIXELATOR_PNA_COMBINE_COLLAPSE": {
-                    "pixelator": "0.22.0"
+                    "pixelator": "0.22.1"
                 },
                 "PIXELATOR_PNA_DEMUX": {
-                    "pixelator": "0.22.0"
+                    "pixelator": "0.22.1"
                 },
                 "PIXELATOR_PNA_DENOISE": {
-                    "pixelator": "0.22.0"
+                    "pixelator": "0.22.1"
                 },
                 "PIXELATOR_PNA_GRAPH": {
-                    "pixelator": "0.22.0"
+                    "pixelator": "0.22.1"
                 },
                 "PIXELATOR_PNA_LAYOUT": {
-                    "pixelator": "0.22.0"
+                    "pixelator": "0.22.1"
                 },
                 "PIXELATOR_PNA_REPORT": {
-                    "pixelator": "0.22.0"
+                    "pixelator": "0.22.1"
                 },
                 "Workflow": {
                     "nf-core/pixelator": "v2.1.0"
@@ -122,7 +122,132 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.0"
         },
-        "timestamp": "2025-10-24T11:24:24.666645628"
+        "timestamp": "2025-10-31T13:57:38.780529335"
+    },
+    "custom panel": {
+        "content": [
+            22,
+            {
+                "EXPERIMENT_SUMMARY": {
+                    "experiment-summary": "0.4.3"
+                },
+                "PIXELATOR_PNA_AMPLICON": {
+                    "pixelator": "0.22.1"
+                },
+                "PIXELATOR_PNA_ANALYSIS": {
+                    "pixelator": "0.22.1"
+                },
+                "PIXELATOR_PNA_COLLAPSE": {
+                    "pixelator": "0.22.1"
+                },
+                "PIXELATOR_PNA_COMBINE_COLLAPSE": {
+                    "pixelator": "0.22.1"
+                },
+                "PIXELATOR_PNA_DEMUX": {
+                    "pixelator": "0.22.1"
+                },
+                "PIXELATOR_PNA_DENOISE": {
+                    "pixelator": "0.22.1"
+                },
+                "PIXELATOR_PNA_GRAPH": {
+                    "pixelator": "0.22.1"
+                },
+                "PIXELATOR_PNA_LAYOUT": {
+                    "pixelator": "0.22.1"
+                },
+                "PIXELATOR_PNA_REPORT": {
+                    "pixelator": "0.22.1"
+                },
+                "Workflow": {
+                    "nf-core/pixelator": "v2.1.0"
+                }
+            },
+            [
+                "pipeline_info",
+                "pipeline_info/nf_core_pixelator_software_mqc_versions.yml",
+                "pixelator",
+                "pixelator/PNA055_Sample07_filtered_S7.layout.pxl",
+                "pixelator/PNA055_Sample07_unfiltered_S7.layout.pxl",
+                "pixelator/amplicon",
+                "pixelator/amplicon/PNA055_Sample07_filtered_S7.meta.json",
+                "pixelator/amplicon/PNA055_Sample07_filtered_S7.report.json",
+                "pixelator/amplicon/PNA055_Sample07_unfiltered_S7.meta.json",
+                "pixelator/amplicon/PNA055_Sample07_unfiltered_S7.report.json",
+                "pixelator/analysis",
+                "pixelator/analysis/PNA055_Sample07_filtered_S7.meta.json",
+                "pixelator/analysis/PNA055_Sample07_filtered_S7.report.json",
+                "pixelator/analysis/PNA055_Sample07_unfiltered_S7.meta.json",
+                "pixelator/analysis/PNA055_Sample07_unfiltered_S7.report.json",
+                "pixelator/collapse",
+                "pixelator/collapse/PNA055_Sample07_filtered_S7.collapse.m1.part_000.meta.json",
+                "pixelator/collapse/PNA055_Sample07_filtered_S7.collapse.m1.part_000.report.json",
+                "pixelator/collapse/PNA055_Sample07_filtered_S7.collapse.m2.part_000.meta.json",
+                "pixelator/collapse/PNA055_Sample07_filtered_S7.collapse.m2.part_000.report.json",
+                "pixelator/collapse/PNA055_Sample07_filtered_S7.collapse.parquet",
+                "pixelator/collapse/PNA055_Sample07_filtered_S7.meta.json",
+                "pixelator/collapse/PNA055_Sample07_filtered_S7.report.json",
+                "pixelator/collapse/PNA055_Sample07_unfiltered_S7.collapse.m1.part_000.meta.json",
+                "pixelator/collapse/PNA055_Sample07_unfiltered_S7.collapse.m1.part_000.report.json",
+                "pixelator/collapse/PNA055_Sample07_unfiltered_S7.collapse.m2.part_000.meta.json",
+                "pixelator/collapse/PNA055_Sample07_unfiltered_S7.collapse.m2.part_000.report.json",
+                "pixelator/collapse/PNA055_Sample07_unfiltered_S7.collapse.parquet",
+                "pixelator/collapse/PNA055_Sample07_unfiltered_S7.meta.json",
+                "pixelator/collapse/PNA055_Sample07_unfiltered_S7.report.json",
+                "pixelator/demux",
+                "pixelator/demux/PNA055_Sample07_filtered_S7.meta.json",
+                "pixelator/demux/PNA055_Sample07_filtered_S7.report.json",
+                "pixelator/demux/PNA055_Sample07_unfiltered_S7.meta.json",
+                "pixelator/demux/PNA055_Sample07_unfiltered_S7.report.json",
+                "pixelator/denoise",
+                "pixelator/denoise/PNA055_Sample07_filtered_S7.meta.json",
+                "pixelator/denoise/PNA055_Sample07_filtered_S7.report.json",
+                "pixelator/denoise/PNA055_Sample07_unfiltered_S7.meta.json",
+                "pixelator/denoise/PNA055_Sample07_unfiltered_S7.report.json",
+                "pixelator/experiment-summary.html",
+                "pixelator/graph",
+                "pixelator/graph/PNA055_Sample07_filtered_S7.meta.json",
+                "pixelator/graph/PNA055_Sample07_filtered_S7.report.json",
+                "pixelator/graph/PNA055_Sample07_unfiltered_S7.meta.json",
+                "pixelator/graph/PNA055_Sample07_unfiltered_S7.report.json",
+                "pixelator/layout",
+                "pixelator/layout/PNA055_Sample07_filtered_S7.meta.json",
+                "pixelator/layout/PNA055_Sample07_filtered_S7.report.json",
+                "pixelator/layout/PNA055_Sample07_unfiltered_S7.meta.json",
+                "pixelator/layout/PNA055_Sample07_unfiltered_S7.report.json",
+                "pixelator/logs",
+                "pixelator/logs/PNA055_Sample07_filtered_S7",
+                "pixelator/logs/PNA055_Sample07_filtered_S7.pixelator-combine-collapse.log",
+                "pixelator/logs/PNA055_Sample07_filtered_S7.pixelator-report.log",
+                "pixelator/logs/PNA055_Sample07_filtered_S7/PNA055_Sample07_filtered_S7.pixelator-amplicon.log",
+                "pixelator/logs/PNA055_Sample07_filtered_S7/PNA055_Sample07_filtered_S7.pixelator-analysis.log",
+                "pixelator/logs/PNA055_Sample07_filtered_S7/PNA055_Sample07_filtered_S7.pixelator-collapse.log",
+                "pixelator/logs/PNA055_Sample07_filtered_S7/PNA055_Sample07_filtered_S7.pixelator-demux.log",
+                "pixelator/logs/PNA055_Sample07_filtered_S7/PNA055_Sample07_filtered_S7.pixelator-denoise.log",
+                "pixelator/logs/PNA055_Sample07_filtered_S7/PNA055_Sample07_filtered_S7.pixelator-graph.log",
+                "pixelator/logs/PNA055_Sample07_filtered_S7/PNA055_Sample07_filtered_S7.pixelator-layout.log",
+                "pixelator/logs/PNA055_Sample07_unfiltered_S7",
+                "pixelator/logs/PNA055_Sample07_unfiltered_S7.pixelator-combine-collapse.log",
+                "pixelator/logs/PNA055_Sample07_unfiltered_S7.pixelator-report.log",
+                "pixelator/logs/PNA055_Sample07_unfiltered_S7/PNA055_Sample07_unfiltered_S7.pixelator-amplicon.log",
+                "pixelator/logs/PNA055_Sample07_unfiltered_S7/PNA055_Sample07_unfiltered_S7.pixelator-analysis.log",
+                "pixelator/logs/PNA055_Sample07_unfiltered_S7/PNA055_Sample07_unfiltered_S7.pixelator-collapse.log",
+                "pixelator/logs/PNA055_Sample07_unfiltered_S7/PNA055_Sample07_unfiltered_S7.pixelator-demux.log",
+                "pixelator/logs/PNA055_Sample07_unfiltered_S7/PNA055_Sample07_unfiltered_S7.pixelator-denoise.log",
+                "pixelator/logs/PNA055_Sample07_unfiltered_S7/PNA055_Sample07_unfiltered_S7.pixelator-graph.log",
+                "pixelator/logs/PNA055_Sample07_unfiltered_S7/PNA055_Sample07_unfiltered_S7.pixelator-layout.log",
+                "pixelator/report",
+                "pixelator/report/PNA055_Sample07_filtered_S7.qc-report.html",
+                "pixelator/report/PNA055_Sample07_unfiltered_S7.qc-report.html"
+            ],
+            [
+                
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.0"
+        },
+        "timestamp": "2025-10-31T14:22:23.503288724"
     },
     "small - stub": {
         "content": [

--- a/tests/save_all.nf.test.snap
+++ b/tests/save_all.nf.test.snap
@@ -4,31 +4,31 @@
             10,
             {
                 "PIXELATOR_AMPLICON": {
-                    "pixelator": "0.22.0"
+                    "pixelator": "0.22.1"
                 },
                 "PIXELATOR_ANALYSIS": {
-                    "pixelator": "0.22.0"
+                    "pixelator": "0.22.1"
                 },
                 "PIXELATOR_ANNOTATE": {
-                    "pixelator": "0.22.0"
+                    "pixelator": "0.22.1"
                 },
                 "PIXELATOR_COLLAPSE": {
-                    "pixelator": "0.22.0"
+                    "pixelator": "0.22.1"
                 },
                 "PIXELATOR_DEMUX": {
-                    "pixelator": "0.22.0"
+                    "pixelator": "0.22.1"
                 },
                 "PIXELATOR_GRAPH": {
-                    "pixelator": "0.22.0"
+                    "pixelator": "0.22.1"
                 },
                 "PIXELATOR_LAYOUT": {
-                    "pixelator": "0.22.0"
+                    "pixelator": "0.22.1"
                 },
                 "PIXELATOR_QC": {
-                    "pixelator": "0.22.0"
+                    "pixelator": "0.22.1"
                 },
                 "PIXELATOR_REPORT": {
-                    "pixelator": "0.22.0"
+                    "pixelator": "0.22.1"
                 },
                 "Workflow": {
                     "nf-core/pixelator": "v2.1.0"
@@ -180,7 +180,7 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.0"
         },
-        "timestamp": "2025-10-24T11:27:51.627957238"
+        "timestamp": "2025-10-31T14:01:22.783604168"
     },
     "Params: --save_all - stub": {
         "content": [


### PR DESCRIPTION
This PR updates pixelator to v0.22.1 and adds a test to make sure the pipeline can run with custom panels.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [X] If you've fixed a bug or added code that should be tested, add tests!
- [X] If necessary, also make a PR on the nf-core/pixelator _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [X] Make sure your code lints (`nf-core pipelines lint`).
- [X] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [X] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [X] `CHANGELOG.md` is updated.
