### PR TITLE
Make nf-core/pixelator compliant with strict syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## dev - xxxx-xx-xx
 
+### Enhancements & fixes
+
+- Use nextflow strict syntax by @Aratz [#194](https://github.com/nf-core/pixelator/pull/194)
+
 ## [[3.0.1](https://github.com/nf-core/pixelator/releases/tag/3.0.0)] - 2026-03-09
 
 ### Enhancements & fixes

--- a/conf/container_env.config
+++ b/conf/container_env.config
@@ -1,0 +1,11 @@
+env {
+    MPLCONFIGDIR               = '/tmp/.config/matplotlib'
+    NUMBA_CACHE_DIR            = "/tmp/.numba_cache"
+
+    // quarto needs a writeable cache directory
+    XDG_CACHE_HOME             = "/tmp/.cache"
+    XDG_DATA_HOME              = "/tmp/.data"
+
+    // DuckDB temp directory when running in containers
+    PIXELATOR_DUCKDB_TEMP_DIR = "/tmp"
+}

--- a/conf/modules.pna.config
+++ b/conf/modules.pna.config
@@ -32,7 +32,7 @@ process {
                 path: { "${params.outdir}/pixelator" },
                 mode: params.publish_dir_mode,
                 pattern: 'amplicon/*.amplicon.fq.zst',
-                saveAs: { params.save_pna_amplicon_reads || params.save_all ? it : null },
+                saveAs: { filename -> params.save_pna_amplicon_reads || params.save_all ? filename : null },
             ],
             [
                 path: { "${params.outdir}/pixelator/logs/${meta.id}" },
@@ -43,7 +43,7 @@ process {
                 path: { "${params.outdir}/pixelator" },
                 mode: params.publish_dir_mode,
                 pattern: '**/*.{report,meta}.json',
-                saveAs: { params.save_json || params.save_all ? it : null },
+                saveAs: { filename -> params.save_json || params.save_all ? filename : null },
             ],
         ]
     }
@@ -62,19 +62,19 @@ process {
                 path: { "${params.outdir}/pixelator" },
                 mode: params.publish_dir_mode,
                 pattern: 'demux/*.parquet',
-                saveAs: { params.save_pna_demux_parquet || params.save_all ? it : null },
+                saveAs: { filename -> params.save_pna_demux_parquet || params.save_all ? filename : null },
             ],
             [
                 path: { "${params.outdir}/pixelator" },
                 mode: params.publish_dir_mode,
                 pattern: 'demux/*.demux.passed.fq.zst',
-                saveAs: { params.save_pna_demux_passed_reads || params.save_all ? it : null },
+                saveAs: { filename -> params.save_pna_demux_passed_reads || params.save_all ? filename : null },
             ],
             [
                 path: { "${params.outdir}/pixelator" },
                 mode: params.publish_dir_mode,
                 pattern: 'demux/*.demux.failed.fq.zst',
-                saveAs: { params.save_pna_demux_failed_reads || params.save_all ? it : null },
+                saveAs: { filename -> params.save_pna_demux_failed_reads || params.save_all ? filename : null },
             ],
             [
                 path: { "${params.outdir}/pixelator/logs/${meta.id}" },
@@ -85,7 +85,7 @@ process {
                 path: { "${params.outdir}/pixelator" },
                 mode: params.publish_dir_mode,
                 pattern: '**/*.{report,meta}.json',
-                saveAs: { params.save_json || params.save_all ? it : null },
+                saveAs: { filename -> params.save_json || params.save_all ? filename : null },
             ],
         ]
     }
@@ -102,7 +102,7 @@ process {
                 path: { "${params.outdir}/pixelator" },
                 mode: params.publish_dir_mode,
                 pattern: 'collapse/*.parquet',
-                saveAs: { params.save_pna_collapsed_reads || params.save_all ? it : null },
+                saveAs: { filename -> params.save_pna_collapsed_reads || params.save_all ? filename : null },
             ],
             [
                 path: { "${params.outdir}/pixelator/logs/${meta.id}" },
@@ -113,7 +113,7 @@ process {
                 path: { "${params.outdir}/pixelator" },
                 mode: params.publish_dir_mode,
                 pattern: '**/*.{report,meta}.json',
-                saveAs: { params.save_json || params.save_all ? it : null },
+                saveAs: { filename -> params.save_json || params.save_all ? filename : null },
             ],
         ]
     }
@@ -141,7 +141,7 @@ process {
                 path: { "${params.outdir}/pixelator" },
                 mode: params.publish_dir_mode,
                 pattern: 'graph/*.pxl',
-                saveAs: { params.save_pna_graph_pixelfile || params.save_all ? it : null },
+                saveAs: { filename -> params.save_pna_graph_pixelfile || params.save_all ? filename : null },
             ],
             [
                 path: { "${params.outdir}/pixelator/logs/${meta.id}" },
@@ -152,7 +152,7 @@ process {
                 path: { "${params.outdir}/pixelator" },
                 mode: params.publish_dir_mode,
                 pattern: '**/*.{report,meta}.json',
-                saveAs: { params.save_json || params.save_all ? it : null },
+                saveAs: { filename -> params.save_json || params.save_all ? filename : null },
             ],
         ]
     }
@@ -171,12 +171,7 @@ process {
                 path: { "${params.outdir}/pixelator" },
                 mode: params.publish_dir_mode,
                 pattern: 'denoise/*.pxl',
-                saveAs: {
-                    if (params.save_pna_denoise_pixelfile) {
-                        return it
-                    }
-                    return null
-                },
+                saveAs: { filename -> params.save_pna_denoise_pixelfile ? filename : null },
             ],
             [
                 path: { "${params.outdir}/pixelator/logs/${meta.id}" },
@@ -187,7 +182,7 @@ process {
                 path: { "${params.outdir}/pixelator" },
                 mode: params.publish_dir_mode,
                 pattern: '**/*.{report,meta}.json',
-                saveAs: { params.save_json ? it : null },
+                saveAs: { filename -> params.save_json ? filename : null },
             ],
         ]
     }
@@ -210,12 +205,7 @@ process {
                 path: { "${params.outdir}/pixelator" },
                 mode: params.publish_dir_mode,
                 pattern: 'analysis/*.pxl',
-                saveAs: {
-                    if (params.save_pna_analysis_pixelfile || params.save_all) {
-                        return it
-                    }
-                    return null
-                },
+                saveAs: { filename -> params.save_pna_analysis_pixelfile || params.save_all ? filename : null },
             ],
             [
                 path: { "${params.outdir}/pixelator/logs/${meta.id}" },
@@ -226,7 +216,7 @@ process {
                 path: { "${params.outdir}/pixelator" },
                 mode: params.publish_dir_mode,
                 pattern: '**/*.{report,meta}.json',
-                saveAs: { params.save_json || params.save_all ? it : null },
+                saveAs: { filename -> params.save_json || params.save_all ? filename : null },
             ],
         ]
     }
@@ -248,7 +238,7 @@ process {
                 pattern: 'layout/*.pxl',
                 saveAs: {
                     // Trim the annotate directory prefix from the output name
-                    new File(it).name
+                    filename -> new File(filename).name
                 },
             ],
             [
@@ -260,7 +250,7 @@ process {
                 path: { "${params.outdir}/pixelator" },
                 mode: params.publish_dir_mode,
                 pattern: '**/*.{report,meta}.json',
-                saveAs: { params.save_json || params.save_all ? it : null },
+                saveAs: { filename -> params.save_json || params.save_all ? filename : null },
             ],
         ]
     }

--- a/modules/local/pixelator/single-cell-pna/amplicon/main.nf
+++ b/modules/local/pixelator/single-cell-pna/amplicon/main.nf
@@ -25,7 +25,6 @@ process PIXELATOR_PNA_AMPLICON {
     script:
     def prefix = task.ext.prefix ?: "${meta.id}"
     def args = task.ext.args ?: ''
-    def r = reads
 
     // Make list of old name and new name pairs to use for renaming
     // Use R1/R2 style suffixes for limited backward compatibility with pixelator<0.17
@@ -34,7 +33,7 @@ process PIXELATOR_PNA_AMPLICON {
         : reads.withIndex().collect { entry, index -> [entry, "${prefix}_R${index + 1}${getFileSuffix(entry)}"] })
     // Flatten a list of tuples into a single string joined with spaces
     def rename_to = old_new_pairs.flatten().join(' ')
-    def renamed_reads = old_new_pairs.collect { old_name, new_name -> new_name }.join(' ')
+    def renamed_reads = old_new_pairs.collect { _old_name, new_name -> new_name }.join(' ')
 
 
     """

--- a/nextflow.config
+++ b/nextflow.config
@@ -129,18 +129,6 @@ params {
 // Load base.config by default for all pipelines
 includeConfig 'conf/base.config'
 
-def container_env_options = [
-    "MPLCONFIGDIR": '/tmp/.config/matplotlib',
-    "NUMBA_CACHE_DIR": "/tmp/.numba_cache",
-
-    // quarto needs a writeable cache directory
-    "XDG_CACHE_HOME": "/tmp/.cache",
-    "XDG_DATA_HOME": "/tmp/.data",
-
-    // DuckDB temp directory when running in containers
-    "PIXELATOR_DUCKDB_TEMP_DIR": "/tmp",
-]
-
 profiles {
     debug {
         dumpHashes                                   = true
@@ -177,7 +165,7 @@ profiles {
         charliecloud.enabled = false
         apptainer.enabled    = false
         docker.runOptions    = '-u $(id -u):$(id -g)'
-        env                  = container_env_options
+        includeConfig 'conf/container_env.config'
     }
     arm64 {
         process.arch            = 'arm64'
@@ -202,7 +190,7 @@ profiles {
         shifter.enabled        = false
         charliecloud.enabled   = false
         apptainer.enabled      = false
-        env                    = container_env_options
+        includeConfig 'conf/container_env.config'
     }
     podman {
         podman.enabled       = true
@@ -213,7 +201,7 @@ profiles {
         charliecloud.enabled = false
         apptainer.enabled    = false
         podman.runOptions    = '--userns=keep-id'
-        env                  = container_env_options
+        includeConfig 'conf/container_env.config'
     }
     shifter {
         shifter.enabled      = true
@@ -223,7 +211,7 @@ profiles {
         podman.enabled       = false
         charliecloud.enabled = false
         apptainer.enabled    = false
-        env                  = container_env_options
+        includeConfig 'conf/container_env.config'
     }
     charliecloud {
         charliecloud.enabled = true
@@ -233,7 +221,7 @@ profiles {
         podman.enabled       = false
         shifter.enabled      = false
         apptainer.enabled    = false
-        env                  = container_env_options
+        includeConfig 'conf/container_env.config'
     }
     apptainer {
         apptainer.enabled    = true
@@ -244,7 +232,7 @@ profiles {
         podman.enabled       = false
         shifter.enabled      = false
         charliecloud.enabled = false
-        env                  = container_env_options
+        includeConfig 'conf/container_env.config'
     }
     wave {
         apptainer.ociAutoPull   = true

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -45,7 +45,7 @@
             }
         },
         "pna_amplicon_options": {
-            "title": "Amplicon generation options",
+            "title": "Amplicon options",
             "type": "object",
             "fa_icon": "fas fa-circle",
             "properties": {
@@ -108,7 +108,7 @@
             }
         },
         "pna_demux_options": {
-            "title": "Demux options for PNA data",
+            "title": "Demux options",
             "type": "object",
             "properties": {
                 "pna_demux_mismatches": {
@@ -192,7 +192,7 @@
             }
         },
         "pna_graph_options": {
-            "title": "Options for pixelator graph command on PNA data.",
+            "title": "Graph options",
             "type": "object",
             "properties": {
                 "save_pna_graph_pixelfile": {
@@ -281,7 +281,7 @@
             }
         },
         "pna_denoise_options": {
-            "title": "Options for pixelator denoise command.",
+            "title": "Denoise options",
             "type": "object",
             "properties": {
                 "skip_denoise": {
@@ -314,7 +314,7 @@
             }
         },
         "pna_analysis_options": {
-            "title": "Options for pixelator analysis command.",
+            "title": "Analysis options",
             "type": "object",
             "properties": {
                 "skip_analysis": {
@@ -358,7 +358,7 @@
             }
         },
         "pna_layout_options": {
-            "title": "Options for pixelator single-cell-pna layout command.",
+            "title": "Layout options",
             "type": "object",
             "properties": {
                 "skip_layout": {
@@ -391,7 +391,7 @@
             }
         },
         "experiment_summary_options": {
-            "title": "Options for experiment summary.",
+            "title": "Experiment Summary options",
             "type": "object",
             "properties": {
                 "skip_experiment_summary": {

--- a/subworkflows/local/pna/generate_reports/main.nf
+++ b/subworkflows/local/pna/generate_reports/main.nf
@@ -32,9 +32,9 @@ workflow PNA_GENERATE_REPORTS {
         .groupTuple()
         .map { id, data ->
             if (data instanceof List) {
-                def newMeta = [:]
-                data.each { newMeta += it }
-                return [id, newMeta]
+                def combined_meta = [:]
+                data.each { meta -> combined_meta += meta }
+                return [id, combined_meta]
             }
             return [id, data]
         }
@@ -86,7 +86,7 @@ workflow PNA_GENERATE_REPORTS {
         EXPERIMENT_SUMMARY ( samplesheet, ch_grouped_data )
         ch_experiment_summary = EXPERIMENT_SUMMARY.out.html
     } else {
-        ch_experiment_summary = ch_grouped_data.map { it -> it[0] }.combine(Channel.of([]))
+        ch_experiment_summary = ch_grouped_data.map { it -> it[0] }.combine(channel.of([]))
     }
 
 

--- a/subworkflows/local/pna/main.nf
+++ b/subworkflows/local/pna/main.nf
@@ -105,14 +105,15 @@ workflow PNA {
             newMeta.remove('parts')
 
             // Strip the duplicates meta from each element
-            def parquet = data.collect { it[1] }.flatten()
-            def reports = data.collect { it[2] }.flatten()
+            def parquet = data.collect { _meta, collapsed, _reports -> collapsed }.flatten()
+            def reports = data.collect { _meta, _collapsed, reports -> reports }.flatten()
             [newMeta, parquet, reports]
         }
 
     ch_collapse_combine_split = ch_collapse_collected.branch {
-        single: it[1].size() == 1
-        multi: it[1].size() > 1
+        _meta, parquet, _reports ->
+            single: parquet.size() == 1
+            multi: parquet.size() > 1
     }
 
 

--- a/subworkflows/local/pna/main.nf
+++ b/subworkflows/local/pna/main.nf
@@ -175,7 +175,7 @@ workflow PNA {
         .groupTuple(size: 2)
 
 
-    ch_input = Channel.fromPath(params.input)
+    ch_input = channel.fromPath(params.input)
 
     PNA_GENERATE_REPORTS(
         ch_input,

--- a/subworkflows/local/utils_nfcore_pixelator_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_pixelator_pipeline/main.nf
@@ -30,7 +30,7 @@ workflow PIPELINE_INITIALISATION {
     take:
     version           // boolean: Display version and exit
     validate_params   // boolean: Boolean whether to validate parameters against the schema at runtime
-    monochrome_logs   // boolean: Do not use coloured log outputs
+    _monochrome_logs   // boolean: Do not use coloured log outputs
     nextflow_cli_args //   array: List of positional nextflow CLI args
     outdir            //  string: The output directory where the results will be saved
     input             //  string: Path to input samplesheet
@@ -324,7 +324,7 @@ def resolve_relative_path(relative_path, URI samplesheet_path) {
     try {
         uri = new URI(relative_path)
     }
-    catch (URISyntaxException exc) {
+    catch (URISyntaxException _exc) {
         return relative_path
     }
 
@@ -394,7 +394,7 @@ def get_data_basedir(URI samplesheet, String input_basedir) {
     try {
         uri = new URI(input_basedir)
     }
-    catch (URISyntaxException exc) {
+    catch (URISyntaxException _exc) {
         return samplesheet
     }
 

--- a/subworkflows/local/utils_nfcore_pixelator_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_pixelator_pipeline/main.nf
@@ -120,7 +120,7 @@ workflow PIPELINE_INITIALISATION {
     ch_input = channel
         .fromList(samplesheetToList(params.input, "${projectDir}/assets/schema_input.json"))
         .map {
-            validate_input_samplesheet(inputBaseDir, it)
+            row -> validate_input_samplesheet(inputBaseDir, row)
         }
 
     //
@@ -131,13 +131,13 @@ workflow PIPELINE_INITIALISATION {
     // Create a set of valid pixelator options to pass to --design
     ch_design_options = PIXELATOR_LIST_OPTIONS.out.designs
         .splitText()
-        .map { it.trim() }
+        .map { design_option -> design_option.trim() }
         .reduce(new HashSet()) { prev, curr -> prev << curr }
 
     // Create a set of valid pixelator panel keys to pass using --panel
     ch_panel_options = PIXELATOR_LIST_OPTIONS.out.panels
         .splitText()
-        .map { it.trim() }
+        .map { panel_option -> panel_option.trim() }
         .reduce(new HashSet()) { prev, curr -> prev << curr }
 
 

--- a/workflows/pixelator.nf
+++ b/workflows/pixelator.nf
@@ -61,8 +61,8 @@ workflow PIXELATOR {
     //
     // Split the samplesheet channel in reads and panel_files
     //
-    ch_reads       = ch_samplesheet.map { meta, panel, reads -> [ meta, reads ] }
-    ch_panel_files = ch_samplesheet.map { meta, panel, reads -> [ meta, panel ] }
+    ch_reads       = ch_samplesheet.map { meta, _panel, reads -> [ meta, reads ] }
+    ch_panel_files = ch_samplesheet.map { meta, panel, _reads -> [ meta, panel ] }
 
     ch_fastq_split = ch_reads
         .groupTuple()
@@ -99,9 +99,9 @@ workflow PIXELATOR {
         }
 
     ch_cat_panel_files = ch_cat_fastq
-        .map { meta, _ -> [meta.id, meta] }
+        .map { meta, _fastqs -> [meta.id, meta] }
         .join(ch_checked_panel_files)
-        .map { id, meta, panel_files -> [meta, panel_files] }
+        .map { _id, meta, panel_files -> [meta, panel_files] }
 
     ch_fastq_technology_split = ch_cat_fastq
         .branch {
@@ -149,7 +149,7 @@ workflow PIXELATOR {
             name: 'nf_core_'  +  'pixelator_software_'  + 'mqc_'  + 'versions.yml',
             sort: true,
             newLine: true
-        ).set { ch_collated_versions }
+        )
 
     emit:
     versions       = ch_versions                 // channel: [ path(versions.yml) ]

--- a/workflows/pixelator.nf
+++ b/workflows/pixelator.nf
@@ -8,11 +8,6 @@ include { paramsSummaryMap       } from 'plugin/nf-schema'
 include { softwareVersionsToYAML } from '../subworkflows/nf-core/utils_nfcore_pipeline'
 include { methodsDescriptionText } from '../subworkflows/local/utils_nfcore_pixelator_pipeline'
 
-// Inject the samplesheet SHA-1 into the params object
-if (params.input) {
-    params.samplesheet_sha = file(params.input).bytes.digest('sha-1')
-}
-
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     CONFIG FILES


### PR DESCRIPTION
This PR addresses the error messages from `nextflow lint`, in order to make the pipeline compliant with the new strict syntax.

Additionally, this renames some option sections to make sure they all follow the same pattern.

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] `CHANGELOG.md` is updated.
