### PR TITLE
Use $TMPDIR to set temporaryr directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Enhancements & fixes
 
 - Use nextflow strict syntax by @Aratz [#194](https://github.com/nf-core/pixelator/pull/194)
+- Use `TMPDIR` when defined to store temporary files by @Aratz [#195](https://github.com/nf-core/pixelator/pull/195)
 
 ## [[3.0.1](https://github.com/nf-core/pixelator/releases/tag/3.0.0)] - 2026-03-09
 

--- a/conf/container_env.config
+++ b/conf/container_env.config
@@ -1,11 +1,11 @@
 env {
-    MPLCONFIGDIR               = '/tmp/.config/matplotlib'
-    NUMBA_CACHE_DIR            = "/tmp/.numba_cache"
+    MPLCONFIGDIR               = '${TMPDIR:-/tmp}/.config/matplotlib'
+    NUMBA_CACHE_DIR            = '${TMPDIR:-/tmp}/.numba_cache'
 
     // quarto needs a writeable cache directory
-    XDG_CACHE_HOME             = "/tmp/.cache"
-    XDG_DATA_HOME              = "/tmp/.data"
+    XDG_CACHE_HOME             = '${TMPDIR:-/tmp}/.cache'
+    XDG_DATA_HOME              = '${TMPDIR:-/tmp}/.data'
 
     // DuckDB temp directory when running in containers
-    PIXELATOR_DUCKDB_TEMP_DIR = "/tmp"
+    PIXELATOR_DUCKDB_TEMP_DIR = '${TMPDIR:-/tmp}'
 }

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -178,6 +178,9 @@ You can find an extensive example of a `params.yaml` file with all options and
 documentation in comments [here](../assets/params-file.yml).
 You can also generate such `YAML`/`JSON` files via [nf-core/launch](https://nf-co.re/launch).
 
+> [!NOTE]
+> By default, processes from nf-core/pixelator will the path defined in `TMPDIR` to store temporary file. If this variable is not defined, they will fallback to `/tmp`.
+
 ### Updating the pipeline
 
 When you run the above command, Nextflow automatically pulls the pipeline code from GitHub and stores it as a cached version. When running the pipeline after this, it will always use the cached version if available - even if the pipeline has been updated since. To make sure that you're running the latest version of the pipeline, make sure that you regularly update the cached version of the pipeline:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -179,7 +179,7 @@ documentation in comments [here](../assets/params-file.yml).
 You can also generate such `YAML`/`JSON` files via [nf-core/launch](https://nf-co.re/launch).
 
 > [!NOTE]
-> By default, processes from nf-core/pixelator will the path defined in `TMPDIR` to store temporary file. If this variable is not defined, they will fallback to `/tmp`.
+> By default, processes from nf-core/pixelator will use the path defined in `TMPDIR` to store temporary file. If this variable is not defined, they will fallback to `/tmp`.
 
 ### Updating the pipeline
 

--- a/nf-test.config
+++ b/nf-test.config
@@ -15,7 +15,7 @@ config {
     profile "test"
 
     // list of filenames or patterns that should be trigger a full test run
-    triggers 'nextflow.config', 'nf-test.config', 'conf/test.config', 'tests/nextflow.config', 'tests/.nftignore', 'assets/schema_input.json', 'nextflow_schema.json'
+    triggers 'nextflow.config', 'conf/container_env.config', 'nf-test.config', 'conf/test.config', 'tests/nextflow.config', 'tests/.nftignore', 'assets/schema_input.json', 'nextflow_schema.json'
 
     // load the necessary plugins
     plugins {


### PR DESCRIPTION
HPC clusters typically specify the scratch area to be used with the environment variable `TMPDIR`. This PR makes sure we use it, and fallback on `/tmp` if it is not defined.

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] `CHANGELOG.md` is updated.

