### PR TITLE
Fix unstable sort order for combine-collapse

### DIFF
--- a/modules/local/pixelator/single-cell-pna/combine_collapse/tests/main.nf.test
+++ b/modules/local/pixelator/single-cell-pna/combine_collapse/tests/main.nf.test
@@ -11,6 +11,7 @@ nextflow_process {
 
 
     test("PNA combine collapse - stub") {
+        tag "stub"
 
         options "-stub"
 

--- a/subworkflows/local/pna/main.nf
+++ b/subworkflows/local/pna/main.nf
@@ -104,9 +104,9 @@ workflow PNA {
             def newMeta = data[0][0].clone()
             newMeta.remove('parts')
 
-            // Strip the duplicates meta from each element
-            def parquet = data.collect { _meta, collapsed, _reports -> collapsed }.flatten()
-            def reports = data.collect { _meta, _collapsed, reports -> reports }.flatten()
+            // Strip duplicate meta and keep a stable ordering to avoid cache misses on resume.
+            def parquet = data.collect { _meta, collapsed, _reports -> collapsed }.flatten().sort { it.toString() }
+            def reports = data.collect { _meta, _collapsed, reports -> reports }.flatten().sort { it.toString() }
             [newMeta, parquet, reports]
         }
 


### PR DESCRIPTION
It seems unstable sort order into the pixelator combine-collapse command will cause it to be rerun on `-resume` even though it has really finished. This tries to fix that.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/pixelator/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/pixelator _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
