### PR TITLE
Setup input size specific resource configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use `TMPDIR` when defined to store temporary files by @Aratz [#195](https://github.com/nf-core/pixelator/pull/195)
 - Retry experiment summary up to two times after failure by @Aratz [#196](https://github.com/nf-core/pixelator/pull/196)
 - Updated pixelatorES to 0.6.0 in PNA experiment summary step by @Aratz [#197](https://github.com/nf-core/pixelator/pull/197)
+- Add `cells_1k` and `cells_8k` Nextflow profiles with process-specific resource overrides for different input scales by @johandahlberg [#202](https://github.com/nf-core/pixelator/pull/202)
 
 ### Software dependencies
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Now, you can run the pipeline using:
 
 ```bash
 nextflow run nf-core/pixelator \
-   -profile <docker/singularity/.../institute> \
+   -profile <docker/singularity/.../institute>,<cells_1k/cells_8k (depending on cell input)> \
    --input samplesheet.csv \
    --outdir <OUTDIR>
 ```

--- a/conf/cells_1k.config
+++ b/conf/cells_1k.config
@@ -1,0 +1,43 @@
+process {
+    // All processes not defined here will rely on process labels and base.config.
+
+    withName: PIXELATOR_PNA_AMPLICON {
+        cpus   = { 32     * task.attempt }
+        memory = { 32.GB * task.attempt }
+        time   = { 4.h   * task.attempt }
+    }
+
+    withName: PIXELATOR_PNA_DEMUX {
+        cpus   = { 16     * task.attempt }
+        memory = { 64.GB * task.attempt }
+        time   = { 4.h   * task.attempt }
+    }
+
+    withName: PIXELATOR_PNA_COLLAPSE {
+        cpus          = { 8 * task.attempt }
+        memory        = { 64.GB * task.attempt }
+        time          = { 8.h * task.attempt }
+        maxRetries    = 4
+        errorStrategy = { task.exitStatus in ((130..145) + 104 + 175 + 1) ? 'retry' : 'finish' }
+    }
+
+    withName: PIXELATOR_PNA_COMBINE_COLLAPSE {
+        cpus       = { 16    * task.attempt }
+        memory     = { 128.GB * task.attempt }
+        time       = { 4.h * task.attempt }
+        maxRetries = 4
+        errorStrategy = { task.exitStatus in ((130..145) + 104 + 175 + 1) ? 'retry' : 'finish' }
+    }
+
+    withName: PIXELATOR_PNA_GRAPH {
+        cpus   = { 12 * task.attempt }
+        memory = { 512.GB * task.attempt }
+        time   = { 10.h * task.attempt }
+    }
+
+    withName: EXPERIMENT_SUMMARY {
+        cpus   = { 16    * task.attempt }
+        memory = { 64.GB * task.attempt }
+        time   = { 12.h  * task.attempt }
+    }
+}

--- a/conf/cells_8k.config
+++ b/conf/cells_8k.config
@@ -1,0 +1,43 @@
+process {
+    // Keep process sizing overrides here for larger (8k cell) runs.
+
+    withName: PIXELATOR_PNA_AMPLICON {
+        cpus   = { 32     * task.attempt }
+        memory = { 32.GB * task.attempt }
+        time   = { 40.h   * task.attempt }
+    }
+
+    withName: PIXELATOR_PNA_DEMUX {
+        cpus   = { 16     * task.attempt }
+        memory = { 128.GB * task.attempt }
+        time   = { 12.h   * task.attempt }
+    }
+
+    withName: PIXELATOR_PNA_COLLAPSE {
+        cpus          = { 8 * task.attempt    }
+        memory        = { 256.GB * task.attempt }
+        time          = { 8.h   * task.attempt }
+        maxRetries    = 4
+        errorStrategy = { task.exitStatus in ((130..145) + 104 + 175 + 1) ? 'retry' : 'finish' }
+    }
+
+    withName: PIXELATOR_PNA_COMBINE_COLLAPSE {
+        cpus       = { 8 * task.attempt }
+        memory     = { 512.GB * task.attempt }
+        time       = { 6.h * task.attempt }
+        maxRetries = 4
+        errorStrategy = { task.exitStatus in ((130..145) + 104 + 175 + 1) ? 'retry' : 'finish' }
+    }
+
+    withName: PIXELATOR_PNA_GRAPH {
+        cpus   = { 12 * task.attempt }
+        memory = { 512.GB * task.attempt }
+        time   = { 20.h * task.attempt }
+    }
+
+    withName: EXPERIMENT_SUMMARY {
+        cpus   = { 16    * task.attempt }
+        memory = { 64.GB * task.attempt }
+        time   = { 12.h  * task.attempt }
+    }
+}

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -139,10 +139,12 @@ pixelator single-cell-pna --list-panels
 The typical command for running the pipeline is as follows:
 
 ```bash
-nextflow run nf-core/pixelator --input ./samplesheet.csv --outdir ./results  -profile docker
+nextflow run nf-core/pixelator --input ./samplesheet.csv --outdir ./results  -profile docker,cells_8k
 ```
 
-This will launch the pipeline with the `docker` configuration profile. See below for more information about profiles.
+This will launch the pipeline with the `docker` configuration profile, and resource configurations
+for 8000 cells. If you have samples with 1000 cells as input, pick the `cells_1k` profile instead.
+See below for more information about profiles.
 
 Note that the pipeline will create the following files in your working directory:
 
@@ -163,7 +165,7 @@ Pipeline settings can be provided in a `yaml` or `json` file via `-params-file <
 The above pipeline run specified with a params file in yaml format:
 
 ```bash
-nextflow run nf-core/pixelator -profile docker -params-file params.yaml
+nextflow run nf-core/pixelator -profile docker,cells_8k -params-file params.yaml
 ```
 
 with:
@@ -242,6 +244,10 @@ If `-profile` is not specified, the pipeline will run locally and expect all sof
   - A generic configuration profile to be used with [Apptainer](https://apptainer.org/)
 - `wave`
   - A generic configuration profile to enable [Wave](https://seqera.io/wave/) containers. Use together with one of the above (requires Nextflow ` 24.03.0-edge` or later).
+- `cells_8k`
+  - A configuration profile for 8000 cells.
+- `cells_1k`
+  - A configuration profile for 1000 cells.
 
 :::warning
 Since Nextflow 23.07.0-edge, Nextflow no longer mounts the host's home directory when using Apptainer or Singularity.

--- a/nextflow.config
+++ b/nextflow.config
@@ -254,6 +254,14 @@ profiles {
     test_full {
         includeConfig 'conf/test_full.config'
     }
+
+    cells_1k {
+        includeConfig 'conf/cells_1k.config'
+    }
+
+    cells_8k {
+        includeConfig 'conf/cells_8k.config'
+    }
 }
 // Load nf-core custom profiles from different institutions
 includeConfig params.custom_config_base && (!System.getenv('NXF_OFFLINE') || !params.custom_config_base.startsWith('http')) ? "${params.custom_config_base}/nfcore_custom.config" : "/dev/null"


### PR DESCRIPTION
Add input size specific resource configs for 1000 and 8000 cells.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/pixelator/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/pixelator _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
