### PR TITLE
Fix Singularity CI tests

### DIFF
--- a/.github/workflows/nf-test.yml
+++ b/.github/workflows/nf-test.yml
@@ -64,6 +64,7 @@ jobs:
     runs-on: # use self-hosted runners
       - runs-on=${{ github.run_id }}-nf-test
       - runner=4cpu-linux-x64
+      - volume=40gb
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/nf-test.yml
+++ b/.github/workflows/nf-test.yml
@@ -77,11 +77,11 @@ jobs:
         exclude:
           - isMain: false
             profile: "conda"
-          - isMain: false
-            profile: "singularity"
+          #- isMain: false
+          #  profile: "singularity"
         NXF_VER:
           - "25.10.4"
-          - "latest-everything"
+          #- "latest-everything"
     env:
       NXF_ANSI_LOG: false
       TOTAL_SHARDS: ${{ needs.nf-test-changes.outputs.total_shards }}

--- a/.github/workflows/nf-test.yml
+++ b/.github/workflows/nf-test.yml
@@ -77,11 +77,11 @@ jobs:
         exclude:
           - isMain: false
             profile: "conda"
-          #- isMain: false
-          #  profile: "singularity"
+          - isMain: false
+            profile: "singularity"
         NXF_VER:
           - "25.10.4"
-          #- "latest-everything"
+          - "latest-everything"
     env:
       NXF_ANSI_LOG: false
       TOTAL_SHARDS: ${{ needs.nf-test-changes.outputs.total_shards }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use `TMPDIR` when defined to store temporary files by @Aratz [#195](https://github.com/nf-core/pixelator/pull/195)
 - Retry experiment summary up to two times after failure by @Aratz [#196](https://github.com/nf-core/pixelator/pull/196)
 - Updated pixelatorES to 0.10.1 in PNA experiment summary step by @Aratz [#197](https://github.com/nf-core/pixelator/pull/197), [#204](https://github.com/nf-core/pixelator/pull/204)
-- Add `cells_1k` and `cells_8k` Nextflow profiles with process-specific resource overrides for different input scales by @johandahlberg [#202](https://github.com/nf-core/pixelator/pull/202)
+- Add `cells_1k` and `cells_8k` Nextflow profiles with process-specific resource overrides for different input scales by @johandahlberg [#203](https://github.com/nf-core/pixelator/pull/203)
 - Fix singularity CI tests by @Aratz [#208](https://github.com/nf-core/pixelator/pull/208)
+- Update nf-core template to 4.0.2 by @Aratz [#202](https://github.com/nf-core/pixelator/pull/202)
 
 ### Software dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Retry experiment summary up to two times after failure by @Aratz [#196](https://github.com/nf-core/pixelator/pull/196)
 - Updated pixelatorES to 0.10.1 in PNA experiment summary step by @Aratz [#197](https://github.com/nf-core/pixelator/pull/197), [#204](https://github.com/nf-core/pixelator/pull/204)
 - Add `cells_1k` and `cells_8k` Nextflow profiles with process-specific resource overrides for different input scales by @johandahlberg [#202](https://github.com/nf-core/pixelator/pull/202)
+- Fix singularity CI tests by @Aratz [#208](https://github.com/nf-core/pixelator/pull/208)
 
 ### Software dependencies
 


### PR DESCRIPTION
The default volume for CI runners was decreased from 40GB to 30GB. This caused the singularity CI tests to fail in PR #207 . This PR increases back the space available to 40GB

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] `CHANGELOG.md` is updated.
