### PR TITLE
Bump version to v4.1.1

### DIFF
--- a/.nf-core.yml
+++ b/.nf-core.yml
@@ -24,4 +24,4 @@ template:
     - fastqc
     - multiqc
     - igenomes
-  version: 4.2.0dev
+  version: 4.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [[4.2.0dev](https://github.com/nf-core/pixelator/releases/tag/4.2.0dev)] - 2026-MM-YY
+## [[4.1.1](https://github.com/nf-core/pixelator/releases/tag/4.1.1)] - 2026-05-29
 
 ### Enhancements & fixes
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -375,7 +375,7 @@ manifest {
     mainScript      = 'main.nf'
     defaultBranch   = 'master'
     nextflowVersion = '!>=25.10.4'
-    version         = '4.2.0dev'
+    version         = '4.1.1'
     doi             = '10.1101/2023.06.05.543770'
 }
 

--- a/ro-crate-metadata.json
+++ b/ro-crate-metadata.json
@@ -21,8 +21,8 @@
         {
             "@id": "./",
             "@type": "Dataset",
-            "creativeWorkStatus": "InProgress",
-            "datePublished": "2026-05-28T09:30:52+00:00",
+            "creativeWorkStatus": "Stable",
+            "datePublished": "2026-05-29T12:26:37+00:00",
             "description": "<h1>\n  <picture>\n    <source media=\"(prefers-color-scheme: dark)\" srcset=\"docs/images/nf-core-pixelator_logo_dark.png\">\n    <img alt=\"nf-core/pixelator\" src=\"docs/images/nf-core-pixelator_logo_light.png\">\n  </picture>\n</h1>\n\n[![Open in GitHub Codespaces](https://img.shields.io/badge/Open_In_GitHub_Codespaces-black?labelColor=grey&logo=github)](https://github.com/codespaces/new/nf-core/pixelator)\n[![GitHub Actions CI Status](https://github.com/nf-core/pixelator/actions/workflows/nf-test.yml/badge.svg)](https://github.com/nf-core/pixelator/actions/workflows/nf-test.yml)\n[![GitHub Actions Linting Status](https://github.com/nf-core/pixelator/actions/workflows/linting.yml/badge.svg)](https://github.com/nf-core/pixelator/actions/workflows/linting.yml)\n[![AWS CI](https://img.shields.io/badge/CI%20tests-full%20size-FF9900?labelColor=000000&logo=Amazon%20AWS)](https://nf-co.re/pixelator/results)\n[![Cite with Zenodo](http://img.shields.io/badge/DOI-10.5281/zenodo.10015112-1073c8?labelColor=000000)](https://doi.org/10.5281/zenodo.10015112)\n[![nf-test](https://img.shields.io/badge/unit_tests-nf--test-337ab7.svg)](https://www.nf-test.com)\n\n[![Nextflow](https://img.shields.io/badge/version-%E2%89%A525.10.4-green?style=flat&logo=nextflow&logoColor=white&color=%230DC09D&link=https%3A%2F%2Fnextflow.io)](https://www.nextflow.io/)\n[![nf-core template version](https://img.shields.io/badge/nf--core_template-4.0.2-green?style=flat&logo=nfcore&logoColor=white&color=%2324B064&link=https%3A%2F%2Fnf-co.re)](https://github.com/nf-core/tools/releases/tag/4.0.2)\n[![run with conda](http://img.shields.io/badge/run%20with-conda-3EB049?labelColor=000000&logo=anaconda)](https://docs.conda.io/en/latest/)\n[![run with docker](https://img.shields.io/badge/run%20with-docker-0db7ed?labelColor=000000&logo=docker)](https://www.docker.com/)\n[![run with singularity](https://img.shields.io/badge/run%20with-singularity-1d355c.svg?labelColor=000000)](https://sylabs.io/docs/)\n[![Launch on Seqera Platform](https://img.shields.io/badge/Launch%20%F0%9F%9A%80-Seqera%20Platform-%234256e7)](https://cloud.seqera.io/launch?pipeline=https://github.com/nf-core/pixelator)\n\n[![Get help on Slack](http://img.shields.io/badge/slack-nf--core%20%23pixelator-4A154B?labelColor=000000&logo=slack)](https://nfcore.slack.com/channels/pixelator)[![Follow on Bluesky](https://img.shields.io/badge/bluesky-%40nf__core-1185fe?labelColor=000000&logo=bluesky)](https://bsky.app/profile/nf-co.re)[![Follow on Mastodon](https://img.shields.io/badge/mastodon-nf__core-6364ff?labelColor=FFFFFF&logo=mastodon)](https://mstdn.science/@nf_core)[![Watch on YouTube](http://img.shields.io/badge/youtube-nf--core-FF0000?labelColor=000000&logo=youtube)](https://www.youtube.com/c/nf-core)\n\n## Introduction\n\n**nf-core/pixelator** is a bioinformatics best-practice analysis pipeline for analysis of data from the\nProximity Network (PNA) assay. It takes a samplesheet as input and will process your data\nusing `pixelator` to produce a PXL file containing single-cell protein abundance and protein interactomics data.\n\n![](./docs/images/nf-core-pixelator-metromap.svg)\n\nThe pipeline will run the following steps:\n\n1. Do quality control checks of input reads and build amplicons ([`pixelator single-cell-pna amplicon`](https://github.com/PixelgenTechnologies/pixelator))\n2. Create groups of amplicons based on their marker assignments ([`pixelator single-cell-pna demux`](https://github.com/PixelgenTechnologies/pixelator))\n3. Derive original molecules to use as edge list downstream by error correcting, and counting input amplicons ([`pixelator single-cell-pna collapse`](https://github.com/PixelgenTechnologies/pixelator))\n4. Compute the components of the graph from the edge list in order to create putative cells ([`pixelator single-cell-pna graph`](https://github.com/PixelgenTechnologies/pixelator))\n5. _(Conditional; only for PNA hashed data)_ Assign components to samples in pooled experiments ([`pixelator single-cell-pna sample-calling`](https://github.com/PixelgenTechnologies/pixelator))\n6. Denoise the cell graphs ([`pixelator single-cell-pna denoise`](https://github.com/PixelgenTechnologies/pixelator))\n7. Analyze the spatial information in the cell graphs ([`pixelator single-cell-pna analysis`](https://github.com/PixelgenTechnologies/pixelator))\n8. Generate 3D graph layouts for visualization of cells ([`pixelator single-cell-pna layout`](https://github.com/PixelgenTechnologies/pixelator))\n9. Proxiome Experiment Summary generation using [PixelatorES](https://github.com/PixelgenTechnologies/pixelatorES)\n\n> [!NOTE]\n> If you are looking to run the pipeline with Molecular Pixelation (MPX) data. Please refer to the [release 2.3.1](https://nf-co.re/pixelator/2.3.1/),\n> which is the last version to support that data type.\n\n> [!WARNING]\n> Since Nextflow 23.07.0-edge, Nextflow no longer mounts the host's home directory when using Apptainer or Singularity.\n> This causes issues in some dependencies. As a workaround, you can revert to the old behavior by setting the environment variable\n> `NXF_APPTAINER_HOME_MOUNT` or `NXF_SINGULARITY_HOME_MOUNT` to `true` in the machine from which you launch the pipeline.\n\n## Usage\n\n> [!NOTE]\n> If you are new to Nextflow and nf-core, please refer to [this page](https://nf-co.re/docs/get_started/environment_setup/overview) on how to set-up Nextflow. Make sure to [test your setup](https://nf-co.re/docs/get_started/run-your-first-pipeline) with `-profile test` before running the workflow on actual data.\n\nFirst, prepare a samplesheet with your input data that looks as follows (the exact values you need to input depend on the design and panel you are using - please see [https://nf-co.re/pixelator/usage](https://nf-co.re/pixelator/usage) for more details).\nFor hashed PNA data (Proxiome kit v2), the samplesheet will look as follows:\n\n`samplesheet.csv`:\n\n```csv\npool,hash_index,sample,sample_alias,condition,design,panel,fastq_1,fastq_2\npool1,1,sample1,s1,control,proxiome-v2,proxiome-v2-immuno-155-v2.0,pool1_R1_001.fastq.gz,pool1_R2_001.fastq.gz\npool1,2,sample2,s2,case,proxiome-v2,proxiome-v2-immuno-155-v2.0,pool1_R1_001.fastq.gz,pool1_R2_001.fastq.gz\npool2,1,sample3,s3,control,proxiome-v2,proxiome-v2-immuno-155-v2.0,pool2_R1_001.fastq.gz,pool2_R2_001.fastq.gz\n```\n\n> [!NOTE]\n> For an example with non-hashed PNA data (Proxiome kit v1), see [Proxiome v1 samplesheet](../assets/example_samplesheet_proxiome_v1.csv)\n\n> [!WARNING]\n> Panel and design names have been completely renamed in pixelator 0.26\n> (nf-core/pixelator 4.0 and above). Refer to the pixelator\n> [changelog](https://github.com/PixelgenTechnologies/pixelator/releases/tag/v0.26.0)\n> for more details.\n\nEach row represents a sample and gives the design, a panel file and the input fastq files.\n\nNow, you can run the pipeline using:\n\n```bash\nnextflow run nf-core/pixelator \\\n   -profile <docker/singularity/.../institute>,<cells_1k/cells_8k (depending on cell input)> \\\n   --technology <proxiome_v1/proxiome_v2 (depending on the kit version used)>\n   --input samplesheet.csv \\\n   --outdir <OUTDIR>\n```\n\n> [!WARNING]\n> This version of the pipeline does not support conda environments, due to issues with upstream dependencies.\n> This means you cannot use the `conda` and `mamba` profiles. Please use `docker` or `singularity` instead.\n> We hope to add support for conda environments in the future.\n\n> [!WARNING]\n> Please provide pipeline parameters via the CLI or Nextflow `-params-file` option. Custom config files including those provided by the `-c` Nextflow option can be used to provide any configuration _**except for parameters**_; see [docs](https://nf-co.re/docs/running/run-pipelines#using-parameter-files).\n\nFor more details and further functionality, please refer to the [usage documentation](https://nf-co.re/pixelator/usage) and the [parameter documentation](https://nf-co.re/pixelator/parameters).\n\n## Pipeline output\n\nTo see the results of an example test run with a full size dataset refer to the [results](https://nf-co.re/pixelator/results) tab on the nf-core website pipeline page.\nFor more details about the output files and reports, please refer to the\n[output documentation](https://nf-co.re/pixelator/output).\n\n## Credits\n\nnf-core/pixelator was originally written for [Pixelgen Technologies AB](https://www.pixelgen.com/) by:\n\n- Florian De Temmerman\n- Johan Dahlberg\n- Alvaro Martinez Barrio\n\n## Contributions and Support\n\nIf you would like to contribute to this pipeline, please see the [contributing guidelines](docs/CONTRIBUTING.md).\n\nFor further information or help, don't hesitate to get in touch on the [Slack `#pixelator` channel](https://nfcore.slack.com/channels/pixelator) (you can join with [this invite](https://nf-co.re/join/slack)).\n\n## Citations\n\nIf you use nf-core/pixelator for your analysis, please cite it using the following doi: [10.5281/zenodo.10015112](https://doi.org/10.5281/zenodo.10015112)\n\nAn extensive list of references for the tools used by the pipeline can be found in the [`CITATIONS.md`](CITATIONS.md) file.\n\nYou can cite the `nf-core` publication as follows:\n\n> **The nf-core framework for community-curated bioinformatics pipelines.**\n>\n> Philip Ewels, Alexander Peltzer, Sven Fillinger, Harshil Patel, Johannes Alneberg, Andreas Wilm, Maxime Ulysse Garcia, Paolo Di Tommaso & Sven Nahnsen.\n>\n> _Nat Biotechnol._ 2020 Feb 13. doi: [10.1038/s41587-020-0439-x](https://dx.doi.org/10.1038/s41587-020-0439-x).\n\nYou can cite the Proximity Network Technology as follows:\n\n> **Single-Cell Protein Interactomes by the Proximity Network Assay.**\n>\n> Filip Karlsson, Michele Simonetti, Christina Galonska, Max Karlsson, Hanna van Ooijen, Tomasz Kallas, Divya Thiagarajan, Maud Schweitzer, Ludvig Larsson, Vincent van Hoef, Pouria Tajvar, Johan Dahlberg, Florian De Temmerman, Louise Leijonancker, Sylvain Geny, Rikard Forlin, Erika Negrini, Stefan Petkov, Lovisa Franz\u00e9n, Jessica Bunz, Christine Moge, Henrik Everberg, Petter Brodin, Alvaro Martinez Barrio, Simon Fredriksson\n>\n> _bioRxiv_ 2025.06.19.660329; doi: [10.1101/2025.06.19.660329](https://doi.org/10.1101/2025.06.19.660329)\n",
             "hasPart": [
                 {
@@ -102,7 +102,7 @@
             },
             "mentions": [
                 {
-                    "@id": "#3e9115fe-9582-405a-ad38-10a3b115a29f"
+                    "@id": "#00706bd6-3b40-441b-b58f-1612b1f4c14c"
                 }
             ],
             "name": "nf-core/pixelator"
@@ -143,7 +143,7 @@
                 }
             ],
             "dateCreated": "",
-            "dateModified": "2026-05-28T11:30:52Z",
+            "dateModified": "2026-05-29T14:26:37Z",
             "dct:conformsTo": "https://bioschemas.org/profiles/ComputationalWorkflow/1.0-RELEASE/",
             "keywords": [
                 "nf-core",
@@ -174,10 +174,10 @@
             },
             "url": [
                 "https://github.com/nf-core/pixelator",
-                "https://nf-co.re/pixelator/dev/"
+                "https://nf-co.re/pixelator/4.1.1/"
             ],
             "version": [
-                "4.2.0dev"
+                "4.1.1"
             ]
         },
         {
@@ -193,11 +193,11 @@
             "version": "!>=25.10.4"
         },
         {
-            "@id": "#3e9115fe-9582-405a-ad38-10a3b115a29f",
+            "@id": "#00706bd6-3b40-441b-b58f-1612b1f4c14c",
             "@type": "TestSuite",
             "instance": [
                 {
-                    "@id": "#e13fc126-cede-4259-a181-60e4110bd73a"
+                    "@id": "#44382bdc-2766-47e3-a6ad-4b279f74cdea"
                 }
             ],
             "mainEntity": {
@@ -206,7 +206,7 @@
             "name": "Test suite for nf-core/pixelator"
         },
         {
-            "@id": "#e13fc126-cede-4259-a181-60e4110bd73a",
+            "@id": "#44382bdc-2766-47e3-a6ad-4b279f74cdea",
             "@type": "TestInstance",
             "name": "GitHub Actions workflow for testing nf-core/pixelator",
             "resource": "repos/nf-core/pixelator/actions/workflows/nf-test.yml",

--- a/tests/proxiome_v1.nf.test.snap
+++ b/tests/proxiome_v1.nf.test.snap
@@ -144,7 +144,7 @@
                     "pixelator": "0.27.2"
                 },
                 "Workflow": {
-                    "nf-core/pixelator": "v4.2.0dev"
+                    "nf-core/pixelator": "v4.1.1"
                 }
             }
         ],
@@ -192,7 +192,7 @@
                     "pixelator": "0.27.2"
                 },
                 "Workflow": {
-                    "nf-core/pixelator": "v4.2.0dev"
+                    "nf-core/pixelator": "v4.1.1"
                 }
             },
             [

--- a/tests/proxiome_v2.nf.test.snap
+++ b/tests/proxiome_v2.nf.test.snap
@@ -181,7 +181,7 @@
                     "pixelator": "0.27.2"
                 },
                 "Workflow": {
-                    "nf-core/pixelator": "v4.2.0dev"
+                    "nf-core/pixelator": "v4.1.1"
                 }
             }
         ],
@@ -229,7 +229,7 @@
                     "pixelator": "0.27.2"
                 },
                 "Workflow": {
-                    "nf-core/pixelator": "v4.2.0dev"
+                    "nf-core/pixelator": "v4.1.1"
                 }
             },
             [


### PR DESCRIPTION
## [[4.1.1](https://github.com/nf-core/pixelator/releases/tag/4.1.1)] - 2026-05-29

### Enhancements & fixes

- Improve documentation by @Aratz [#216](https://github.com/nf-core/pixelator/pull/216)
- Update pixelator by @Aratz [#217](https://github.com/nf-core/pixelator/pull/217)

### Software dependencies

| Dependency  | Old version | New version |
| ----------- | ----------- | ----------- |
| `pixelator` | 0.27.1      | 0.27.2      |