### PR TITLE
Update pixelator to 0.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [[4.2.0dev](https://github.com/nf-core/pixelator/releases/tag/4.2.0)] - 2026-MM-DD
+## [[4.1.2dev](https://github.com/nf-core/pixelator/releases/tag/4.1.1)] - 2026-MM-DD
 
 ### Enhancements & fixes
 
-- Update pixelator container to 0.28.0
+- Update pixelator container to 0.28.0. This fixes a major performance regression
+  in the graph step, which caused very high memory usage.
 
 ### Software dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [[4.2.0dev](https://github.com/nf-core/pixelator/releases/tag/4.2.0)] - 2026-MM-DD
 
+### Enhancements & fixes
+
+- Update pixelator container to 0.28.0
+
+### Software dependencies
+
+| Dependency  | Old version | New version |
+| ----------- | ----------- | ----------- |
+| `pixelator` | 0.27.2      | 0.28.0      |
+
 ## [[4.1.1](https://github.com/nf-core/pixelator/releases/tag/4.1.1)] - 2026-05-29
 
 ### Enhancements & fixes

--- a/modules/local/pixelator/amplicon/main.nf
+++ b/modules/local/pixelator/amplicon/main.nf
@@ -5,8 +5,8 @@ process PIXELATOR_AMPLICON {
     // TODO: Add conda
     // conda "bioconda::pixelator=0.18.2"
     container "${params.pixelator_container?:workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'quay.io/pixelgen-technologies/pixelator:0.27.2'
-        : 'quay.io/pixelgen-technologies/pixelator:0.27.2'}"
+        ? 'quay.io/pixelgen-technologies/pixelator:0.28.0'
+        : 'quay.io/pixelgen-technologies/pixelator:0.28.0'}"
 
     input:
     tuple val(meta), path(reads, arity: '1..*')

--- a/modules/local/pixelator/amplicon/tests/main.nf.test.snap
+++ b/modules/local/pixelator/amplicon/tests/main.nf.test.snap
@@ -60,7 +60,7 @@
                     [
                         "PIXELATOR_AMPLICON",
                         "pixelator",
-                        "0.27.2"
+                        "0.28.0"
                     ]
                 ],
                 "amplicon": [
@@ -111,7 +111,7 @@
                     [
                         "PIXELATOR_AMPLICON",
                         "pixelator",
-                        "0.27.2"
+                        "0.28.0"
                     ]
                 ]
             }
@@ -140,7 +140,7 @@
                 [
                     "PIXELATOR_AMPLICON",
                     "pixelator",
-                    "0.27.2"
+                    "0.28.0"
                 ]
             ]
         ],

--- a/modules/local/pixelator/analysis/main.nf
+++ b/modules/local/pixelator/analysis/main.nf
@@ -6,8 +6,8 @@ process PIXELATOR_ANALYSIS {
     // conda "bioconda::pixelator=0.18.2"
 
     container "${params.pixelator_container?:workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'quay.io/pixelgen-technologies/pixelator:0.27.2'
-        : 'quay.io/pixelgen-technologies/pixelator:0.27.2'}"
+        ? 'quay.io/pixelgen-technologies/pixelator:0.28.0'
+        : 'quay.io/pixelgen-technologies/pixelator:0.28.0'}"
 
     input:
     tuple val(meta), path(data)

--- a/modules/local/pixelator/analysis/tests/main.nf.test.snap
+++ b/modules/local/pixelator/analysis/tests/main.nf.test.snap
@@ -17,7 +17,7 @@
                 [
                     "PIXELATOR_ANALYSIS",
                     "pixelator",
-                    "0.27.2"
+                    "0.28.0"
                 ]
             ]
         ],
@@ -103,7 +103,7 @@
                     [
                         "PIXELATOR_ANALYSIS",
                         "pixelator",
-                        "0.27.2"
+                        "0.28.0"
                     ]
                 ],
                 "all_results": [
@@ -169,7 +169,7 @@
                     [
                         "PIXELATOR_ANALYSIS",
                         "pixelator",
-                        "0.27.2"
+                        "0.28.0"
                     ]
                 ]
             }

--- a/modules/local/pixelator/collapse/main.nf
+++ b/modules/local/pixelator/collapse/main.nf
@@ -7,8 +7,8 @@ process PIXELATOR_COLLAPSE {
     // TODO: Add conda
     // conda "bioconda::pixelator=0.18.2"
     container "${params.pixelator_container?:workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'quay.io/pixelgen-technologies/pixelator:0.27.2'
-        : 'quay.io/pixelgen-technologies/pixelator:0.27.2'}"
+        ? 'quay.io/pixelgen-technologies/pixelator:0.28.0'
+        : 'quay.io/pixelgen-technologies/pixelator:0.28.0'}"
 
     input:
     tuple val(meta), path(reads), path(panel_file), val(panel), val(design)

--- a/modules/local/pixelator/collapse/tests/main.nf.test.snap
+++ b/modules/local/pixelator/collapse/tests/main.nf.test.snap
@@ -17,7 +17,7 @@
                 [
                     "PIXELATOR_COLLAPSE",
                     "pixelator",
-                    "0.27.2"
+                    "0.28.0"
                 ]
             ]
         ],
@@ -92,7 +92,7 @@
                     [
                         "PIXELATOR_COLLAPSE",
                         "pixelator",
-                        "0.27.2"
+                        "0.28.0"
                     ]
                 ],
                 "collapsed": [
@@ -147,7 +147,7 @@
                     [
                         "PIXELATOR_COLLAPSE",
                         "pixelator",
-                        "0.27.2"
+                        "0.28.0"
                     ]
                 ]
             }

--- a/modules/local/pixelator/combine_collapse/main.nf
+++ b/modules/local/pixelator/combine_collapse/main.nf
@@ -6,8 +6,8 @@ process PIXELATOR_COMBINE_COLLAPSE {
     // conda "bioconda::pixelator=0.18.2"
 
     container "${params.pixelator_container?:workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'quay.io/pixelgen-technologies/pixelator:0.27.2'
-        : 'quay.io/pixelgen-technologies/pixelator:0.27.2'}"
+        ? 'quay.io/pixelgen-technologies/pixelator:0.28.0'
+        : 'quay.io/pixelgen-technologies/pixelator:0.28.0'}"
 
     input:
     tuple val(meta), path(parquet_files, stageAs: "parquet/*"), path(json_report_files, stageAs: "reports/*")

--- a/modules/local/pixelator/combine_collapse/tests/main.nf.test.snap
+++ b/modules/local/pixelator/combine_collapse/tests/main.nf.test.snap
@@ -16,7 +16,7 @@
                 [
                     "PIXELATOR_COMBINE_COLLAPSE",
                     "pixelator",
-                    "0.27.2"
+                    "0.28.0"
                 ]
             ]
         ],
@@ -87,7 +87,7 @@
                     [
                         "PIXELATOR_COMBINE_COLLAPSE",
                         "pixelator",
-                        "0.27.2"
+                        "0.28.0"
                     ]
                 ],
                 "log": [
@@ -138,7 +138,7 @@
                     [
                         "PIXELATOR_COMBINE_COLLAPSE",
                         "pixelator",
-                        "0.27.2"
+                        "0.28.0"
                     ]
                 ]
             }

--- a/modules/local/pixelator/demux/main.nf
+++ b/modules/local/pixelator/demux/main.nf
@@ -6,8 +6,8 @@ process PIXELATOR_DEMUX {
     // conda "bioconda::pixelator=0.18.2"
 
     container "${params.pixelator_container?:workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'quay.io/pixelgen-technologies/pixelator:0.27.2'
-        : 'quay.io/pixelgen-technologies/pixelator:0.27.2'}"
+        ? 'quay.io/pixelgen-technologies/pixelator:0.28.0'
+        : 'quay.io/pixelgen-technologies/pixelator:0.28.0'}"
 
     input:
     tuple val(meta), path(reads), path(panel_file), val(panel), val(design)

--- a/modules/local/pixelator/demux/tests/main.nf.test.snap
+++ b/modules/local/pixelator/demux/tests/main.nf.test.snap
@@ -20,7 +20,7 @@
                 [
                     "PIXELATOR_DEMUX",
                     "pixelator",
-                    "0.27.2"
+                    "0.28.0"
                 ]
             ]
         ],
@@ -119,7 +119,7 @@
                     [
                         "PIXELATOR_DEMUX",
                         "pixelator",
-                        "0.27.2"
+                        "0.28.0"
                     ]
                 ],
                 "demuxed": [
@@ -195,7 +195,7 @@
                     [
                         "PIXELATOR_DEMUX",
                         "pixelator",
-                        "0.27.2"
+                        "0.28.0"
                     ]
                 ]
             }
@@ -241,7 +241,7 @@
                 [
                     "PIXELATOR_DEMUX",
                     "pixelator",
-                    "0.27.2"
+                    "0.28.0"
                 ]
             ]
         ],

--- a/modules/local/pixelator/denoise/main.nf
+++ b/modules/local/pixelator/denoise/main.nf
@@ -6,8 +6,8 @@ process PIXELATOR_DENOISE {
     // conda "bioconda::pixelator=0.18.2"
 
     container "${params.pixelator_container?:workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'quay.io/pixelgen-technologies/pixelator:0.27.2'
-        : 'quay.io/pixelgen-technologies/pixelator:0.27.2'}"
+        ? 'quay.io/pixelgen-technologies/pixelator:0.28.0'
+        : 'quay.io/pixelgen-technologies/pixelator:0.28.0'}"
 
     input:
     tuple val(meta), path(data)

--- a/modules/local/pixelator/denoise/tests/main.nf.test.snap
+++ b/modules/local/pixelator/denoise/tests/main.nf.test.snap
@@ -16,7 +16,7 @@
                 [
                     "PIXELATOR_DENOISE",
                     "pixelator",
-                    "0.27.2"
+                    "0.28.0"
                 ]
             ]
         ],
@@ -102,7 +102,7 @@
                     [
                         "PIXELATOR_DENOISE",
                         "pixelator",
-                        "0.27.2"
+                        "0.28.0"
                     ]
                 ],
                 "all_results": [
@@ -168,7 +168,7 @@
                     [
                         "PIXELATOR_DENOISE",
                         "pixelator",
-                        "0.27.2"
+                        "0.28.0"
                     ]
                 ]
             }

--- a/modules/local/pixelator/graph/main.nf
+++ b/modules/local/pixelator/graph/main.nf
@@ -4,8 +4,8 @@ process PIXELATOR_GRAPH {
     label 'process_long'
 
     container "${params.pixelator_container?:workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'quay.io/pixelgen-technologies/pixelator:0.27.2'
-        : 'quay.io/pixelgen-technologies/pixelator:0.27.2'}"
+        ? 'quay.io/pixelgen-technologies/pixelator:0.28.0'
+        : 'quay.io/pixelgen-technologies/pixelator:0.28.0'}"
 
     input:
     tuple val(meta), path(edge_list), path(panel_file), val(panel)

--- a/modules/local/pixelator/graph/tests/main.nf.test.snap
+++ b/modules/local/pixelator/graph/tests/main.nf.test.snap
@@ -75,7 +75,7 @@
                     [
                         "PIXELATOR_GRAPH",
                         "pixelator",
-                        "0.27.2"
+                        "0.28.0"
                     ]
                 ],
                 "all_results": [
@@ -141,7 +141,7 @@
                     [
                         "PIXELATOR_GRAPH",
                         "pixelator",
-                        "0.27.2"
+                        "0.28.0"
                     ]
                 ]
             }
@@ -170,7 +170,7 @@
                 [
                     "PIXELATOR_GRAPH",
                     "pixelator",
-                    "0.27.2"
+                    "0.28.0"
                 ]
             ]
         ],

--- a/modules/local/pixelator/layout/main.nf
+++ b/modules/local/pixelator/layout/main.nf
@@ -5,8 +5,8 @@ process PIXELATOR_LAYOUT {
     // TODO: Add conda
     // conda "bioconda::pixelator=0.18.2"
     container "${params.pixelator_container?:workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'quay.io/pixelgen-technologies/pixelator:0.27.2'
-        : 'quay.io/pixelgen-technologies/pixelator:0.27.2'}"
+        ? 'quay.io/pixelgen-technologies/pixelator:0.28.0'
+        : 'quay.io/pixelgen-technologies/pixelator:0.28.0'}"
 
     input:
     tuple val(meta), path(data)

--- a/modules/local/pixelator/layout/tests/main.nf.test.snap
+++ b/modules/local/pixelator/layout/tests/main.nf.test.snap
@@ -17,7 +17,7 @@
                 [
                     "PIXELATOR_LAYOUT",
                     "pixelator",
-                    "0.27.2"
+                    "0.28.0"
                 ]
             ]
         ],
@@ -103,7 +103,7 @@
                     [
                         "PIXELATOR_LAYOUT",
                         "pixelator",
-                        "0.27.2"
+                        "0.28.0"
                     ]
                 ],
                 "all_results": [
@@ -169,7 +169,7 @@
                     [
                         "PIXELATOR_LAYOUT",
                         "pixelator",
-                        "0.27.2"
+                        "0.28.0"
                     ]
                 ]
             }

--- a/modules/local/pixelator/list_options/main.nf
+++ b/modules/local/pixelator/list_options/main.nf
@@ -5,8 +5,8 @@ process PIXELATOR_LIST_OPTIONS {
     // TODO: Add conda back
     // conda "${moduleDir}/environment.yml"
     container "${params.pixelator_container?:workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'quay.io/pixelgen-technologies/pixelator:0.27.2'
-        : 'quay.io/pixelgen-technologies/pixelator:0.27.2'}"
+        ? 'quay.io/pixelgen-technologies/pixelator:0.28.0'
+        : 'quay.io/pixelgen-technologies/pixelator:0.28.0'}"
 
     output:
     path "design_options.txt", emit: designs

--- a/modules/local/pixelator/sample_calling/main.nf
+++ b/modules/local/pixelator/sample_calling/main.nf
@@ -5,8 +5,8 @@ process PIXELATOR_SAMPLE_CALLING {
     // TODO: Add conda
     // conda "bioconda::pixelator=0.18.2"
     container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'quay.io/pixelgen-technologies/pixelator:0.27.2'
-        : 'quay.io/pixelgen-technologies/pixelator:0.27.2'}"
+        ? 'quay.io/pixelgen-technologies/pixelator:0.28.0'
+        : 'quay.io/pixelgen-technologies/pixelator:0.28.0'}"
 
     input:
     tuple val(meta), path(data), path(samplesheet)

--- a/modules/local/pixelator/sample_calling/tests/main.nf.test.snap
+++ b/modules/local/pixelator/sample_calling/tests/main.nf.test.snap
@@ -111,7 +111,7 @@
                     ]
                 ],
                 "6": [
-                    "versions.yml:md5,b92ce490993aa65332cf3e1fce6c4ff7"
+                    "versions.yml:md5,caecdbbf67cdc742583ac0658769573d"
                 ],
                 "all_results": [
                     [
@@ -181,7 +181,7 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,b92ce490993aa65332cf3e1fce6c4ff7"
+                    "versions.yml:md5,caecdbbf67cdc742583ac0658769573d"
                 ]
             }
         ],

--- a/nextflow.config
+++ b/nextflow.config
@@ -375,7 +375,7 @@ manifest {
     mainScript      = 'main.nf'
     defaultBranch   = 'master'
     nextflowVersion = '!>=25.10.4'
-    version         = '4.2.0dev'
+    version         = '4.1.2dev'
     doi             = '10.1101/2023.06.05.543770'
 }
 

--- a/tests/proxiome_v1.nf.test.snap
+++ b/tests/proxiome_v1.nf.test.snap
@@ -144,7 +144,7 @@
                     "pixelator": "0.28.0"
                 },
                 "Workflow": {
-                    "nf-core/pixelator": "v4.2.0dev"
+                    "nf-core/pixelator": "v4.1.2dev"
                 }
             }
         ],
@@ -192,7 +192,7 @@
                     "pixelator": "0.28.0"
                 },
                 "Workflow": {
-                    "nf-core/pixelator": "v4.2.0dev"
+                    "nf-core/pixelator": "v4.1.2dev"
                 }
             },
             [

--- a/tests/proxiome_v1.nf.test.snap
+++ b/tests/proxiome_v1.nf.test.snap
@@ -117,31 +117,31 @@
                     "experiment-summary": "0.10.4"
                 },
                 "PIXELATOR_AMPLICON": {
-                    "pixelator": "0.27.2"
+                    "pixelator": "0.28.0"
                 },
                 "PIXELATOR_ANALYSIS": {
-                    "pixelator": "0.27.2"
+                    "pixelator": "0.28.0"
                 },
                 "PIXELATOR_COLLAPSE": {
-                    "pixelator": "0.27.2"
+                    "pixelator": "0.28.0"
                 },
                 "PIXELATOR_COMBINE_COLLAPSE": {
-                    "pixelator": "0.27.2"
+                    "pixelator": "0.28.0"
                 },
                 "PIXELATOR_DEMUX": {
-                    "pixelator": "0.27.2"
+                    "pixelator": "0.28.0"
                 },
                 "PIXELATOR_DENOISE": {
-                    "pixelator": "0.27.2"
+                    "pixelator": "0.28.0"
                 },
                 "PIXELATOR_GRAPH": {
-                    "pixelator": "0.27.2"
+                    "pixelator": "0.28.0"
                 },
                 "PIXELATOR_LAYOUT": {
-                    "pixelator": "0.27.2"
+                    "pixelator": "0.28.0"
                 },
                 "PIXELATOR_LIST_OPTIONS": {
-                    "pixelator": "0.27.2"
+                    "pixelator": "0.28.0"
                 },
                 "Workflow": {
                     "nf-core/pixelator": "v4.2.0dev"
@@ -165,31 +165,31 @@
                     "experiment-summary": "0.10.4"
                 },
                 "PIXELATOR_AMPLICON": {
-                    "pixelator": "0.27.2"
+                    "pixelator": "0.28.0"
                 },
                 "PIXELATOR_ANALYSIS": {
-                    "pixelator": "0.27.2"
+                    "pixelator": "0.28.0"
                 },
                 "PIXELATOR_COLLAPSE": {
-                    "pixelator": "0.27.2"
+                    "pixelator": "0.28.0"
                 },
                 "PIXELATOR_COMBINE_COLLAPSE": {
-                    "pixelator": "0.27.2"
+                    "pixelator": "0.28.0"
                 },
                 "PIXELATOR_DEMUX": {
-                    "pixelator": "0.27.2"
+                    "pixelator": "0.28.0"
                 },
                 "PIXELATOR_DENOISE": {
-                    "pixelator": "0.27.2"
+                    "pixelator": "0.28.0"
                 },
                 "PIXELATOR_GRAPH": {
-                    "pixelator": "0.27.2"
+                    "pixelator": "0.28.0"
                 },
                 "PIXELATOR_LAYOUT": {
-                    "pixelator": "0.27.2"
+                    "pixelator": "0.28.0"
                 },
                 "PIXELATOR_LIST_OPTIONS": {
-                    "pixelator": "0.27.2"
+                    "pixelator": "0.28.0"
                 },
                 "Workflow": {
                     "nf-core/pixelator": "v4.2.0dev"

--- a/tests/proxiome_v2.nf.test.snap
+++ b/tests/proxiome_v2.nf.test.snap
@@ -154,31 +154,31 @@
                     "experiment-summary": "0.10.4"
                 },
                 "PIXELATOR_AMPLICON": {
-                    "pixelator": "0.27.2"
+                    "pixelator": "0.28.0"
                 },
                 "PIXELATOR_ANALYSIS": {
-                    "pixelator": "0.27.2"
+                    "pixelator": "0.28.0"
                 },
                 "PIXELATOR_COLLAPSE": {
-                    "pixelator": "0.27.2"
+                    "pixelator": "0.28.0"
                 },
                 "PIXELATOR_COMBINE_COLLAPSE": {
-                    "pixelator": "0.27.2"
+                    "pixelator": "0.28.0"
                 },
                 "PIXELATOR_DEMUX": {
-                    "pixelator": "0.27.2"
+                    "pixelator": "0.28.0"
                 },
                 "PIXELATOR_DENOISE": {
-                    "pixelator": "0.27.2"
+                    "pixelator": "0.28.0"
                 },
                 "PIXELATOR_GRAPH": {
-                    "pixelator": "0.27.2"
+                    "pixelator": "0.28.0"
                 },
                 "PIXELATOR_LAYOUT": {
-                    "pixelator": "0.27.2"
+                    "pixelator": "0.28.0"
                 },
                 "PIXELATOR_LIST_OPTIONS": {
-                    "pixelator": "0.27.2"
+                    "pixelator": "0.28.0"
                 },
                 "Workflow": {
                     "nf-core/pixelator": "v4.2.0dev"
@@ -202,31 +202,31 @@
                     "experiment-summary": "0.10.4"
                 },
                 "PIXELATOR_AMPLICON": {
-                    "pixelator": "0.27.2"
+                    "pixelator": "0.28.0"
                 },
                 "PIXELATOR_ANALYSIS": {
-                    "pixelator": "0.27.2"
+                    "pixelator": "0.28.0"
                 },
                 "PIXELATOR_COLLAPSE": {
-                    "pixelator": "0.27.2"
+                    "pixelator": "0.28.0"
                 },
                 "PIXELATOR_COMBINE_COLLAPSE": {
-                    "pixelator": "0.27.2"
+                    "pixelator": "0.28.0"
                 },
                 "PIXELATOR_DEMUX": {
-                    "pixelator": "0.27.2"
+                    "pixelator": "0.28.0"
                 },
                 "PIXELATOR_DENOISE": {
-                    "pixelator": "0.27.2"
+                    "pixelator": "0.28.0"
                 },
                 "PIXELATOR_GRAPH": {
-                    "pixelator": "0.27.2"
+                    "pixelator": "0.28.0"
                 },
                 "PIXELATOR_LAYOUT": {
-                    "pixelator": "0.27.2"
+                    "pixelator": "0.28.0"
                 },
                 "PIXELATOR_LIST_OPTIONS": {
-                    "pixelator": "0.27.2"
+                    "pixelator": "0.28.0"
                 },
                 "Workflow": {
                     "nf-core/pixelator": "v4.2.0dev"

--- a/tests/proxiome_v2.nf.test.snap
+++ b/tests/proxiome_v2.nf.test.snap
@@ -181,7 +181,7 @@
                     "pixelator": "0.28.0"
                 },
                 "Workflow": {
-                    "nf-core/pixelator": "v4.2.0dev"
+                    "nf-core/pixelator": "v4.1.2dev"
                 }
             }
         ],
@@ -229,7 +229,7 @@
                     "pixelator": "0.28.0"
                 },
                 "Workflow": {
-                    "nf-core/pixelator": "v4.2.0dev"
+                    "nf-core/pixelator": "v4.1.2dev"
                 }
             },
             [


### PR DESCRIPTION
This updates pixelator to 0.28.0, which fixes a major performance regression in the graph step that caused memory usage to balloon up to roughly 8x.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/pixelator/tree/master/docs/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/pixelator _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
