### PR TITLE
Release 4.1.2

### DIFF
--- a/.nf-core.yml
+++ b/.nf-core.yml
@@ -24,4 +24,4 @@ template:
     - fastqc
     - multiqc
     - igenomes
-  version: 4.1.1
+  version: 4.2.0dev

--- a/.nf-core.yml
+++ b/.nf-core.yml
@@ -24,4 +24,4 @@ template:
     - fastqc
     - multiqc
     - igenomes
-  version: 4.2.0dev
+  version: 4.1.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [[4.1.2dev](https://github.com/nf-core/pixelator/releases/tag/4.1.1)] - 2026-MM-DD
+## [[4.1.2](https://github.com/nf-core/pixelator/releases/tag/4.1.2)] - 2026-06-04
 
 ### Enhancements & fixes
 
 - Update pixelator container to 0.28.0. This fixes a major performance regression
-  in the graph step, which caused very high memory usage.
+  in the graph step, which caused very high memory usage. By @johandahlberg [#221](https://github.com/nf-core/pixelator/pull/221)
 
 ### Software dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [[4.2.0dev](https://github.com/nf-core/pixelator/releases/tag/4.2.0)] - 2026-MM-DD
+## [[4.1.2dev](https://github.com/nf-core/pixelator/releases/tag/4.1.1)] - 2026-MM-DD
 
 ### Enhancements & fixes
 
-- Update pixelator container to 0.28.0
+- Update pixelator container to 0.28.0. This fixes a major performance regression
+  in the graph step, which caused very high memory usage.
 
 ### Software dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [[4.2.0dev](https://github.com/nf-core/pixelator/releases/tag/4.2.0)] - 2026-MM-DD
+
 ## [[4.1.1](https://github.com/nf-core/pixelator/releases/tag/4.1.1)] - 2026-05-29
 
 ### Enhancements & fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [[4.2.0dev](https://github.com/nf-core/pixelator/releases/tag/4.2.0)] - 2026-MM-DD
 
+### Enhancements & fixes
+
+- Update pixelator container to 0.28.0
+
+### Software dependencies
+
+| Dependency  | Old version | New version |
+| ----------- | ----------- | ----------- |
+| `pixelator` | 0.27.2      | 0.28.0      |
+
 ## [[4.1.1](https://github.com/nf-core/pixelator/releases/tag/4.1.1)] - 2026-05-29
 
 ### Enhancements & fixes

--- a/modules/local/pixelator/amplicon/main.nf
+++ b/modules/local/pixelator/amplicon/main.nf
@@ -5,8 +5,8 @@ process PIXELATOR_AMPLICON {
     // TODO: Add conda
     // conda "bioconda::pixelator=0.18.2"
     container "${params.pixelator_container?:workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'quay.io/pixelgen-technologies/pixelator:0.27.2'
-        : 'quay.io/pixelgen-technologies/pixelator:0.27.2'}"
+        ? 'quay.io/pixelgen-technologies/pixelator:0.28.0'
+        : 'quay.io/pixelgen-technologies/pixelator:0.28.0'}"
 
     input:
     tuple val(meta), path(reads, arity: '1..*')

--- a/modules/local/pixelator/amplicon/tests/main.nf.test.snap
+++ b/modules/local/pixelator/amplicon/tests/main.nf.test.snap
@@ -60,7 +60,7 @@
                     [
                         "PIXELATOR_AMPLICON",
                         "pixelator",
-                        "0.27.2"
+                        "0.28.0"
                     ]
                 ],
                 "amplicon": [
@@ -111,7 +111,7 @@
                     [
                         "PIXELATOR_AMPLICON",
                         "pixelator",
-                        "0.27.2"
+                        "0.28.0"
                     ]
                 ]
             }
@@ -140,7 +140,7 @@
                 [
                     "PIXELATOR_AMPLICON",
                     "pixelator",
-                    "0.27.2"
+                    "0.28.0"
                 ]
             ]
         ],

--- a/modules/local/pixelator/analysis/main.nf
+++ b/modules/local/pixelator/analysis/main.nf
@@ -6,8 +6,8 @@ process PIXELATOR_ANALYSIS {
     // conda "bioconda::pixelator=0.18.2"
 
     container "${params.pixelator_container?:workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'quay.io/pixelgen-technologies/pixelator:0.27.2'
-        : 'quay.io/pixelgen-technologies/pixelator:0.27.2'}"
+        ? 'quay.io/pixelgen-technologies/pixelator:0.28.0'
+        : 'quay.io/pixelgen-technologies/pixelator:0.28.0'}"
 
     input:
     tuple val(meta), path(data)

--- a/modules/local/pixelator/analysis/tests/main.nf.test.snap
+++ b/modules/local/pixelator/analysis/tests/main.nf.test.snap
@@ -17,7 +17,7 @@
                 [
                     "PIXELATOR_ANALYSIS",
                     "pixelator",
-                    "0.27.2"
+                    "0.28.0"
                 ]
             ]
         ],
@@ -103,7 +103,7 @@
                     [
                         "PIXELATOR_ANALYSIS",
                         "pixelator",
-                        "0.27.2"
+                        "0.28.0"
                     ]
                 ],
                 "all_results": [
@@ -169,7 +169,7 @@
                     [
                         "PIXELATOR_ANALYSIS",
                         "pixelator",
-                        "0.27.2"
+                        "0.28.0"
                     ]
                 ]
             }

--- a/modules/local/pixelator/collapse/main.nf
+++ b/modules/local/pixelator/collapse/main.nf
@@ -7,8 +7,8 @@ process PIXELATOR_COLLAPSE {
     // TODO: Add conda
     // conda "bioconda::pixelator=0.18.2"
     container "${params.pixelator_container?:workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'quay.io/pixelgen-technologies/pixelator:0.27.2'
-        : 'quay.io/pixelgen-technologies/pixelator:0.27.2'}"
+        ? 'quay.io/pixelgen-technologies/pixelator:0.28.0'
+        : 'quay.io/pixelgen-technologies/pixelator:0.28.0'}"
 
     input:
     tuple val(meta), path(reads), path(panel_file), val(panel), val(design)

--- a/modules/local/pixelator/collapse/tests/main.nf.test.snap
+++ b/modules/local/pixelator/collapse/tests/main.nf.test.snap
@@ -17,7 +17,7 @@
                 [
                     "PIXELATOR_COLLAPSE",
                     "pixelator",
-                    "0.27.2"
+                    "0.28.0"
                 ]
             ]
         ],
@@ -92,7 +92,7 @@
                     [
                         "PIXELATOR_COLLAPSE",
                         "pixelator",
-                        "0.27.2"
+                        "0.28.0"
                     ]
                 ],
                 "collapsed": [
@@ -147,7 +147,7 @@
                     [
                         "PIXELATOR_COLLAPSE",
                         "pixelator",
-                        "0.27.2"
+                        "0.28.0"
                     ]
                 ]
             }

--- a/modules/local/pixelator/combine_collapse/main.nf
+++ b/modules/local/pixelator/combine_collapse/main.nf
@@ -6,8 +6,8 @@ process PIXELATOR_COMBINE_COLLAPSE {
     // conda "bioconda::pixelator=0.18.2"
 
     container "${params.pixelator_container?:workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'quay.io/pixelgen-technologies/pixelator:0.27.2'
-        : 'quay.io/pixelgen-technologies/pixelator:0.27.2'}"
+        ? 'quay.io/pixelgen-technologies/pixelator:0.28.0'
+        : 'quay.io/pixelgen-technologies/pixelator:0.28.0'}"
 
     input:
     tuple val(meta), path(parquet_files, stageAs: "parquet/*"), path(json_report_files, stageAs: "reports/*")

--- a/modules/local/pixelator/combine_collapse/tests/main.nf.test.snap
+++ b/modules/local/pixelator/combine_collapse/tests/main.nf.test.snap
@@ -16,7 +16,7 @@
                 [
                     "PIXELATOR_COMBINE_COLLAPSE",
                     "pixelator",
-                    "0.27.2"
+                    "0.28.0"
                 ]
             ]
         ],
@@ -87,7 +87,7 @@
                     [
                         "PIXELATOR_COMBINE_COLLAPSE",
                         "pixelator",
-                        "0.27.2"
+                        "0.28.0"
                     ]
                 ],
                 "log": [
@@ -138,7 +138,7 @@
                     [
                         "PIXELATOR_COMBINE_COLLAPSE",
                         "pixelator",
-                        "0.27.2"
+                        "0.28.0"
                     ]
                 ]
             }

--- a/modules/local/pixelator/demux/main.nf
+++ b/modules/local/pixelator/demux/main.nf
@@ -6,8 +6,8 @@ process PIXELATOR_DEMUX {
     // conda "bioconda::pixelator=0.18.2"
 
     container "${params.pixelator_container?:workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'quay.io/pixelgen-technologies/pixelator:0.27.2'
-        : 'quay.io/pixelgen-technologies/pixelator:0.27.2'}"
+        ? 'quay.io/pixelgen-technologies/pixelator:0.28.0'
+        : 'quay.io/pixelgen-technologies/pixelator:0.28.0'}"
 
     input:
     tuple val(meta), path(reads), path(panel_file), val(panel), val(design)

--- a/modules/local/pixelator/demux/tests/main.nf.test.snap
+++ b/modules/local/pixelator/demux/tests/main.nf.test.snap
@@ -20,7 +20,7 @@
                 [
                     "PIXELATOR_DEMUX",
                     "pixelator",
-                    "0.27.2"
+                    "0.28.0"
                 ]
             ]
         ],
@@ -119,7 +119,7 @@
                     [
                         "PIXELATOR_DEMUX",
                         "pixelator",
-                        "0.27.2"
+                        "0.28.0"
                     ]
                 ],
                 "demuxed": [
@@ -195,7 +195,7 @@
                     [
                         "PIXELATOR_DEMUX",
                         "pixelator",
-                        "0.27.2"
+                        "0.28.0"
                     ]
                 ]
             }
@@ -241,7 +241,7 @@
                 [
                     "PIXELATOR_DEMUX",
                     "pixelator",
-                    "0.27.2"
+                    "0.28.0"
                 ]
             ]
         ],

--- a/modules/local/pixelator/denoise/main.nf
+++ b/modules/local/pixelator/denoise/main.nf
@@ -6,8 +6,8 @@ process PIXELATOR_DENOISE {
     // conda "bioconda::pixelator=0.18.2"
 
     container "${params.pixelator_container?:workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'quay.io/pixelgen-technologies/pixelator:0.27.2'
-        : 'quay.io/pixelgen-technologies/pixelator:0.27.2'}"
+        ? 'quay.io/pixelgen-technologies/pixelator:0.28.0'
+        : 'quay.io/pixelgen-technologies/pixelator:0.28.0'}"
 
     input:
     tuple val(meta), path(data)

--- a/modules/local/pixelator/denoise/tests/main.nf.test.snap
+++ b/modules/local/pixelator/denoise/tests/main.nf.test.snap
@@ -16,7 +16,7 @@
                 [
                     "PIXELATOR_DENOISE",
                     "pixelator",
-                    "0.27.2"
+                    "0.28.0"
                 ]
             ]
         ],
@@ -102,7 +102,7 @@
                     [
                         "PIXELATOR_DENOISE",
                         "pixelator",
-                        "0.27.2"
+                        "0.28.0"
                     ]
                 ],
                 "all_results": [
@@ -168,7 +168,7 @@
                     [
                         "PIXELATOR_DENOISE",
                         "pixelator",
-                        "0.27.2"
+                        "0.28.0"
                     ]
                 ]
             }

--- a/modules/local/pixelator/graph/main.nf
+++ b/modules/local/pixelator/graph/main.nf
@@ -4,8 +4,8 @@ process PIXELATOR_GRAPH {
     label 'process_long'
 
     container "${params.pixelator_container?:workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'quay.io/pixelgen-technologies/pixelator:0.27.2'
-        : 'quay.io/pixelgen-technologies/pixelator:0.27.2'}"
+        ? 'quay.io/pixelgen-technologies/pixelator:0.28.0'
+        : 'quay.io/pixelgen-technologies/pixelator:0.28.0'}"
 
     input:
     tuple val(meta), path(edge_list), path(panel_file), val(panel)

--- a/modules/local/pixelator/graph/tests/main.nf.test.snap
+++ b/modules/local/pixelator/graph/tests/main.nf.test.snap
@@ -75,7 +75,7 @@
                     [
                         "PIXELATOR_GRAPH",
                         "pixelator",
-                        "0.27.2"
+                        "0.28.0"
                     ]
                 ],
                 "all_results": [
@@ -141,7 +141,7 @@
                     [
                         "PIXELATOR_GRAPH",
                         "pixelator",
-                        "0.27.2"
+                        "0.28.0"
                     ]
                 ]
             }
@@ -170,7 +170,7 @@
                 [
                     "PIXELATOR_GRAPH",
                     "pixelator",
-                    "0.27.2"
+                    "0.28.0"
                 ]
             ]
         ],

--- a/modules/local/pixelator/layout/main.nf
+++ b/modules/local/pixelator/layout/main.nf
@@ -5,8 +5,8 @@ process PIXELATOR_LAYOUT {
     // TODO: Add conda
     // conda "bioconda::pixelator=0.18.2"
     container "${params.pixelator_container?:workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'quay.io/pixelgen-technologies/pixelator:0.27.2'
-        : 'quay.io/pixelgen-technologies/pixelator:0.27.2'}"
+        ? 'quay.io/pixelgen-technologies/pixelator:0.28.0'
+        : 'quay.io/pixelgen-technologies/pixelator:0.28.0'}"
 
     input:
     tuple val(meta), path(data)

--- a/modules/local/pixelator/layout/tests/main.nf.test.snap
+++ b/modules/local/pixelator/layout/tests/main.nf.test.snap
@@ -17,7 +17,7 @@
                 [
                     "PIXELATOR_LAYOUT",
                     "pixelator",
-                    "0.27.2"
+                    "0.28.0"
                 ]
             ]
         ],
@@ -103,7 +103,7 @@
                     [
                         "PIXELATOR_LAYOUT",
                         "pixelator",
-                        "0.27.2"
+                        "0.28.0"
                     ]
                 ],
                 "all_results": [
@@ -169,7 +169,7 @@
                     [
                         "PIXELATOR_LAYOUT",
                         "pixelator",
-                        "0.27.2"
+                        "0.28.0"
                     ]
                 ]
             }

--- a/modules/local/pixelator/list_options/main.nf
+++ b/modules/local/pixelator/list_options/main.nf
@@ -5,8 +5,8 @@ process PIXELATOR_LIST_OPTIONS {
     // TODO: Add conda back
     // conda "${moduleDir}/environment.yml"
     container "${params.pixelator_container?:workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'quay.io/pixelgen-technologies/pixelator:0.27.2'
-        : 'quay.io/pixelgen-technologies/pixelator:0.27.2'}"
+        ? 'quay.io/pixelgen-technologies/pixelator:0.28.0'
+        : 'quay.io/pixelgen-technologies/pixelator:0.28.0'}"
 
     output:
     path "design_options.txt", emit: designs

--- a/modules/local/pixelator/sample_calling/main.nf
+++ b/modules/local/pixelator/sample_calling/main.nf
@@ -5,8 +5,8 @@ process PIXELATOR_SAMPLE_CALLING {
     // TODO: Add conda
     // conda "bioconda::pixelator=0.18.2"
     container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'quay.io/pixelgen-technologies/pixelator:0.27.2'
-        : 'quay.io/pixelgen-technologies/pixelator:0.27.2'}"
+        ? 'quay.io/pixelgen-technologies/pixelator:0.28.0'
+        : 'quay.io/pixelgen-technologies/pixelator:0.28.0'}"
 
     input:
     tuple val(meta), path(data), path(samplesheet)

--- a/modules/local/pixelator/sample_calling/tests/main.nf.test.snap
+++ b/modules/local/pixelator/sample_calling/tests/main.nf.test.snap
@@ -111,7 +111,7 @@
                     ]
                 ],
                 "6": [
-                    "versions.yml:md5,b92ce490993aa65332cf3e1fce6c4ff7"
+                    "versions.yml:md5,caecdbbf67cdc742583ac0658769573d"
                 ],
                 "all_results": [
                     [
@@ -181,7 +181,7 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,b92ce490993aa65332cf3e1fce6c4ff7"
+                    "versions.yml:md5,caecdbbf67cdc742583ac0658769573d"
                 ]
             }
         ],

--- a/nextflow.config
+++ b/nextflow.config
@@ -375,7 +375,7 @@ manifest {
     mainScript      = 'main.nf'
     defaultBranch   = 'master'
     nextflowVersion = '!>=25.10.4'
-    version         = '4.1.1'
+    version         = '4.2.0dev'
     doi             = '10.1101/2023.06.05.543770'
 }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -375,7 +375,7 @@ manifest {
     mainScript      = 'main.nf'
     defaultBranch   = 'master'
     nextflowVersion = '!>=25.10.4'
-    version         = '4.2.0dev'
+    version         = '4.1.2dev'
     doi             = '10.1101/2023.06.05.543770'
 }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -375,7 +375,7 @@ manifest {
     mainScript      = 'main.nf'
     defaultBranch   = 'master'
     nextflowVersion = '!>=25.10.4'
-    version         = '4.1.2dev'
+    version         = '4.1.2'
     doi             = '10.1101/2023.06.05.543770'
 }
 

--- a/ro-crate-metadata.json
+++ b/ro-crate-metadata.json
@@ -21,8 +21,8 @@
         {
             "@id": "./",
             "@type": "Dataset",
-            "creativeWorkStatus": "Stable",
-            "datePublished": "2026-05-29T12:26:37+00:00",
+            "creativeWorkStatus": "InProgress",
+            "datePublished": "2026-05-29T13:57:42+00:00",
             "description": "<h1>\n  <picture>\n    <source media=\"(prefers-color-scheme: dark)\" srcset=\"docs/images/nf-core-pixelator_logo_dark.png\">\n    <img alt=\"nf-core/pixelator\" src=\"docs/images/nf-core-pixelator_logo_light.png\">\n  </picture>\n</h1>\n\n[![Open in GitHub Codespaces](https://img.shields.io/badge/Open_In_GitHub_Codespaces-black?labelColor=grey&logo=github)](https://github.com/codespaces/new/nf-core/pixelator)\n[![GitHub Actions CI Status](https://github.com/nf-core/pixelator/actions/workflows/nf-test.yml/badge.svg)](https://github.com/nf-core/pixelator/actions/workflows/nf-test.yml)\n[![GitHub Actions Linting Status](https://github.com/nf-core/pixelator/actions/workflows/linting.yml/badge.svg)](https://github.com/nf-core/pixelator/actions/workflows/linting.yml)\n[![AWS CI](https://img.shields.io/badge/CI%20tests-full%20size-FF9900?labelColor=000000&logo=Amazon%20AWS)](https://nf-co.re/pixelator/results)\n[![Cite with Zenodo](http://img.shields.io/badge/DOI-10.5281/zenodo.10015112-1073c8?labelColor=000000)](https://doi.org/10.5281/zenodo.10015112)\n[![nf-test](https://img.shields.io/badge/unit_tests-nf--test-337ab7.svg)](https://www.nf-test.com)\n\n[![Nextflow](https://img.shields.io/badge/version-%E2%89%A525.10.4-green?style=flat&logo=nextflow&logoColor=white&color=%230DC09D&link=https%3A%2F%2Fnextflow.io)](https://www.nextflow.io/)\n[![nf-core template version](https://img.shields.io/badge/nf--core_template-4.0.2-green?style=flat&logo=nfcore&logoColor=white&color=%2324B064&link=https%3A%2F%2Fnf-co.re)](https://github.com/nf-core/tools/releases/tag/4.0.2)\n[![run with conda](http://img.shields.io/badge/run%20with-conda-3EB049?labelColor=000000&logo=anaconda)](https://docs.conda.io/en/latest/)\n[![run with docker](https://img.shields.io/badge/run%20with-docker-0db7ed?labelColor=000000&logo=docker)](https://www.docker.com/)\n[![run with singularity](https://img.shields.io/badge/run%20with-singularity-1d355c.svg?labelColor=000000)](https://sylabs.io/docs/)\n[![Launch on Seqera Platform](https://img.shields.io/badge/Launch%20%F0%9F%9A%80-Seqera%20Platform-%234256e7)](https://cloud.seqera.io/launch?pipeline=https://github.com/nf-core/pixelator)\n\n[![Get help on Slack](http://img.shields.io/badge/slack-nf--core%20%23pixelator-4A154B?labelColor=000000&logo=slack)](https://nfcore.slack.com/channels/pixelator)[![Follow on Bluesky](https://img.shields.io/badge/bluesky-%40nf__core-1185fe?labelColor=000000&logo=bluesky)](https://bsky.app/profile/nf-co.re)[![Follow on Mastodon](https://img.shields.io/badge/mastodon-nf__core-6364ff?labelColor=FFFFFF&logo=mastodon)](https://mstdn.science/@nf_core)[![Watch on YouTube](http://img.shields.io/badge/youtube-nf--core-FF0000?labelColor=000000&logo=youtube)](https://www.youtube.com/c/nf-core)\n\n## Introduction\n\n**nf-core/pixelator** is a bioinformatics best-practice analysis pipeline for analysis of data from the\nProximity Network (PNA) assay. It takes a samplesheet as input and will process your data\nusing `pixelator` to produce a PXL file containing single-cell protein abundance and protein interactomics data.\n\n![](./docs/images/nf-core-pixelator-metromap.svg)\n\nThe pipeline will run the following steps:\n\n1. Do quality control checks of input reads and build amplicons ([`pixelator single-cell-pna amplicon`](https://github.com/PixelgenTechnologies/pixelator))\n2. Create groups of amplicons based on their marker assignments ([`pixelator single-cell-pna demux`](https://github.com/PixelgenTechnologies/pixelator))\n3. Derive original molecules to use as edge list downstream by error correcting, and counting input amplicons ([`pixelator single-cell-pna collapse`](https://github.com/PixelgenTechnologies/pixelator))\n4. Compute the components of the graph from the edge list in order to create putative cells ([`pixelator single-cell-pna graph`](https://github.com/PixelgenTechnologies/pixelator))\n5. _(Conditional; only for PNA hashed data)_ Assign components to samples in pooled experiments ([`pixelator single-cell-pna sample-calling`](https://github.com/PixelgenTechnologies/pixelator))\n6. Denoise the cell graphs ([`pixelator single-cell-pna denoise`](https://github.com/PixelgenTechnologies/pixelator))\n7. Analyze the spatial information in the cell graphs ([`pixelator single-cell-pna analysis`](https://github.com/PixelgenTechnologies/pixelator))\n8. Generate 3D graph layouts for visualization of cells ([`pixelator single-cell-pna layout`](https://github.com/PixelgenTechnologies/pixelator))\n9. Proxiome Experiment Summary generation using [PixelatorES](https://github.com/PixelgenTechnologies/pixelatorES)\n\n> [!NOTE]\n> If you are looking to run the pipeline with Molecular Pixelation (MPX) data. Please refer to the [release 2.3.1](https://nf-co.re/pixelator/2.3.1/),\n> which is the last version to support that data type.\n\n> [!WARNING]\n> Since Nextflow 23.07.0-edge, Nextflow no longer mounts the host's home directory when using Apptainer or Singularity.\n> This causes issues in some dependencies. As a workaround, you can revert to the old behavior by setting the environment variable\n> `NXF_APPTAINER_HOME_MOUNT` or `NXF_SINGULARITY_HOME_MOUNT` to `true` in the machine from which you launch the pipeline.\n\n## Usage\n\n> [!NOTE]\n> If you are new to Nextflow and nf-core, please refer to [this page](https://nf-co.re/docs/get_started/environment_setup/overview) on how to set-up Nextflow. Make sure to [test your setup](https://nf-co.re/docs/get_started/run-your-first-pipeline) with `-profile test` before running the workflow on actual data.\n\nFirst, prepare a samplesheet with your input data that looks as follows (the exact values you need to input depend on the design and panel you are using - please see [https://nf-co.re/pixelator/usage](https://nf-co.re/pixelator/usage) for more details).\nFor hashed PNA data (Proxiome kit v2), the samplesheet will look as follows:\n\n`samplesheet.csv`:\n\n```csv\npool,hash_index,sample,sample_alias,condition,design,panel,fastq_1,fastq_2\npool1,1,sample1,s1,control,proxiome-v2,proxiome-v2-immuno-155-v2.0,pool1_R1_001.fastq.gz,pool1_R2_001.fastq.gz\npool1,2,sample2,s2,case,proxiome-v2,proxiome-v2-immuno-155-v2.0,pool1_R1_001.fastq.gz,pool1_R2_001.fastq.gz\npool2,1,sample3,s3,control,proxiome-v2,proxiome-v2-immuno-155-v2.0,pool2_R1_001.fastq.gz,pool2_R2_001.fastq.gz\n```\n\n> [!NOTE]\n> For an example with non-hashed PNA data (Proxiome kit v1), see [Proxiome v1 samplesheet](../assets/example_samplesheet_proxiome_v1.csv)\n\n> [!WARNING]\n> Panel and design names have been completely renamed in pixelator 0.26\n> (nf-core/pixelator 4.0 and above). Refer to the pixelator\n> [changelog](https://github.com/PixelgenTechnologies/pixelator/releases/tag/v0.26.0)\n> for more details.\n\nEach row represents a sample and gives the design, a panel file and the input fastq files.\n\nNow, you can run the pipeline using:\n\n```bash\nnextflow run nf-core/pixelator \\\n   -profile <docker/singularity/.../institute>,<cells_1k/cells_8k (depending on cell input)> \\\n   --technology <proxiome_v1/proxiome_v2 (depending on the kit version used)>\n   --input samplesheet.csv \\\n   --outdir <OUTDIR>\n```\n\n> [!WARNING]\n> This version of the pipeline does not support conda environments, due to issues with upstream dependencies.\n> This means you cannot use the `conda` and `mamba` profiles. Please use `docker` or `singularity` instead.\n> We hope to add support for conda environments in the future.\n\n> [!WARNING]\n> Please provide pipeline parameters via the CLI or Nextflow `-params-file` option. Custom config files including those provided by the `-c` Nextflow option can be used to provide any configuration _**except for parameters**_; see [docs](https://nf-co.re/docs/running/run-pipelines#using-parameter-files).\n\nFor more details and further functionality, please refer to the [usage documentation](https://nf-co.re/pixelator/usage) and the [parameter documentation](https://nf-co.re/pixelator/parameters).\n\n## Pipeline output\n\nTo see the results of an example test run with a full size dataset refer to the [results](https://nf-co.re/pixelator/results) tab on the nf-core website pipeline page.\nFor more details about the output files and reports, please refer to the\n[output documentation](https://nf-co.re/pixelator/output).\n\n## Credits\n\nnf-core/pixelator was originally written for [Pixelgen Technologies AB](https://www.pixelgen.com/) by:\n\n- Florian De Temmerman\n- Johan Dahlberg\n- Alvaro Martinez Barrio\n\n## Contributions and Support\n\nIf you would like to contribute to this pipeline, please see the [contributing guidelines](docs/CONTRIBUTING.md).\n\nFor further information or help, don't hesitate to get in touch on the [Slack `#pixelator` channel](https://nfcore.slack.com/channels/pixelator) (you can join with [this invite](https://nf-co.re/join/slack)).\n\n## Citations\n\nIf you use nf-core/pixelator for your analysis, please cite it using the following doi: [10.5281/zenodo.10015112](https://doi.org/10.5281/zenodo.10015112)\n\nAn extensive list of references for the tools used by the pipeline can be found in the [`CITATIONS.md`](CITATIONS.md) file.\n\nYou can cite the `nf-core` publication as follows:\n\n> **The nf-core framework for community-curated bioinformatics pipelines.**\n>\n> Philip Ewels, Alexander Peltzer, Sven Fillinger, Harshil Patel, Johannes Alneberg, Andreas Wilm, Maxime Ulysse Garcia, Paolo Di Tommaso & Sven Nahnsen.\n>\n> _Nat Biotechnol._ 2020 Feb 13. doi: [10.1038/s41587-020-0439-x](https://dx.doi.org/10.1038/s41587-020-0439-x).\n\nYou can cite the Proximity Network Technology as follows:\n\n> **Single-Cell Protein Interactomes by the Proximity Network Assay.**\n>\n> Filip Karlsson, Michele Simonetti, Christina Galonska, Max Karlsson, Hanna van Ooijen, Tomasz Kallas, Divya Thiagarajan, Maud Schweitzer, Ludvig Larsson, Vincent van Hoef, Pouria Tajvar, Johan Dahlberg, Florian De Temmerman, Louise Leijonancker, Sylvain Geny, Rikard Forlin, Erika Negrini, Stefan Petkov, Lovisa Franz\u00e9n, Jessica Bunz, Christine Moge, Henrik Everberg, Petter Brodin, Alvaro Martinez Barrio, Simon Fredriksson\n>\n> _bioRxiv_ 2025.06.19.660329; doi: [10.1101/2025.06.19.660329](https://doi.org/10.1101/2025.06.19.660329)\n",
             "hasPart": [
                 {
@@ -102,7 +102,7 @@
             },
             "mentions": [
                 {
-                    "@id": "#00706bd6-3b40-441b-b58f-1612b1f4c14c"
+                    "@id": "#b08e9a66-f8b8-4587-9a7e-10048983d129"
                 }
             ],
             "name": "nf-core/pixelator"
@@ -143,7 +143,7 @@
                 }
             ],
             "dateCreated": "",
-            "dateModified": "2026-05-29T14:26:37Z",
+            "dateModified": "2026-05-29T15:57:42Z",
             "dct:conformsTo": "https://bioschemas.org/profiles/ComputationalWorkflow/1.0-RELEASE/",
             "keywords": [
                 "nf-core",
@@ -174,10 +174,10 @@
             },
             "url": [
                 "https://github.com/nf-core/pixelator",
-                "https://nf-co.re/pixelator/4.1.1/"
+                "https://nf-co.re/pixelator/dev/"
             ],
             "version": [
-                "4.1.1"
+                "4.2.0dev"
             ]
         },
         {
@@ -193,11 +193,11 @@
             "version": "!>=25.10.4"
         },
         {
-            "@id": "#00706bd6-3b40-441b-b58f-1612b1f4c14c",
+            "@id": "#b08e9a66-f8b8-4587-9a7e-10048983d129",
             "@type": "TestSuite",
             "instance": [
                 {
-                    "@id": "#44382bdc-2766-47e3-a6ad-4b279f74cdea"
+                    "@id": "#1ea56774-5744-4332-bf43-225123fa4115"
                 }
             ],
             "mainEntity": {
@@ -206,7 +206,7 @@
             "name": "Test suite for nf-core/pixelator"
         },
         {
-            "@id": "#44382bdc-2766-47e3-a6ad-4b279f74cdea",
+            "@id": "#1ea56774-5744-4332-bf43-225123fa4115",
             "@type": "TestInstance",
             "name": "GitHub Actions workflow for testing nf-core/pixelator",
             "resource": "repos/nf-core/pixelator/actions/workflows/nf-test.yml",

--- a/ro-crate-metadata.json
+++ b/ro-crate-metadata.json
@@ -21,8 +21,8 @@
         {
             "@id": "./",
             "@type": "Dataset",
-            "creativeWorkStatus": "InProgress",
-            "datePublished": "2026-05-29T13:57:42+00:00",
+            "creativeWorkStatus": "Stable",
+            "datePublished": "2026-06-04T07:56:31+00:00",
             "description": "<h1>\n  <picture>\n    <source media=\"(prefers-color-scheme: dark)\" srcset=\"docs/images/nf-core-pixelator_logo_dark.png\">\n    <img alt=\"nf-core/pixelator\" src=\"docs/images/nf-core-pixelator_logo_light.png\">\n  </picture>\n</h1>\n\n[![Open in GitHub Codespaces](https://img.shields.io/badge/Open_In_GitHub_Codespaces-black?labelColor=grey&logo=github)](https://github.com/codespaces/new/nf-core/pixelator)\n[![GitHub Actions CI Status](https://github.com/nf-core/pixelator/actions/workflows/nf-test.yml/badge.svg)](https://github.com/nf-core/pixelator/actions/workflows/nf-test.yml)\n[![GitHub Actions Linting Status](https://github.com/nf-core/pixelator/actions/workflows/linting.yml/badge.svg)](https://github.com/nf-core/pixelator/actions/workflows/linting.yml)\n[![AWS CI](https://img.shields.io/badge/CI%20tests-full%20size-FF9900?labelColor=000000&logo=Amazon%20AWS)](https://nf-co.re/pixelator/results)\n[![Cite with Zenodo](http://img.shields.io/badge/DOI-10.5281/zenodo.10015112-1073c8?labelColor=000000)](https://doi.org/10.5281/zenodo.10015112)\n[![nf-test](https://img.shields.io/badge/unit_tests-nf--test-337ab7.svg)](https://www.nf-test.com)\n\n[![Nextflow](https://img.shields.io/badge/version-%E2%89%A525.10.4-green?style=flat&logo=nextflow&logoColor=white&color=%230DC09D&link=https%3A%2F%2Fnextflow.io)](https://www.nextflow.io/)\n[![nf-core template version](https://img.shields.io/badge/nf--core_template-4.0.2-green?style=flat&logo=nfcore&logoColor=white&color=%2324B064&link=https%3A%2F%2Fnf-co.re)](https://github.com/nf-core/tools/releases/tag/4.0.2)\n[![run with conda](http://img.shields.io/badge/run%20with-conda-3EB049?labelColor=000000&logo=anaconda)](https://docs.conda.io/en/latest/)\n[![run with docker](https://img.shields.io/badge/run%20with-docker-0db7ed?labelColor=000000&logo=docker)](https://www.docker.com/)\n[![run with singularity](https://img.shields.io/badge/run%20with-singularity-1d355c.svg?labelColor=000000)](https://sylabs.io/docs/)\n[![Launch on Seqera Platform](https://img.shields.io/badge/Launch%20%F0%9F%9A%80-Seqera%20Platform-%234256e7)](https://cloud.seqera.io/launch?pipeline=https://github.com/nf-core/pixelator)\n\n[![Get help on Slack](http://img.shields.io/badge/slack-nf--core%20%23pixelator-4A154B?labelColor=000000&logo=slack)](https://nfcore.slack.com/channels/pixelator)[![Follow on Bluesky](https://img.shields.io/badge/bluesky-%40nf__core-1185fe?labelColor=000000&logo=bluesky)](https://bsky.app/profile/nf-co.re)[![Follow on Mastodon](https://img.shields.io/badge/mastodon-nf__core-6364ff?labelColor=FFFFFF&logo=mastodon)](https://mstdn.science/@nf_core)[![Watch on YouTube](http://img.shields.io/badge/youtube-nf--core-FF0000?labelColor=000000&logo=youtube)](https://www.youtube.com/c/nf-core)\n\n## Introduction\n\n**nf-core/pixelator** is a bioinformatics best-practice analysis pipeline for analysis of data from the\nProximity Network (PNA) assay. It takes a samplesheet as input and will process your data\nusing `pixelator` to produce a PXL file containing single-cell protein abundance and protein interactomics data.\n\n![](./docs/images/nf-core-pixelator-metromap.svg)\n\nThe pipeline will run the following steps:\n\n1. Do quality control checks of input reads and build amplicons ([`pixelator single-cell-pna amplicon`](https://github.com/PixelgenTechnologies/pixelator))\n2. Create groups of amplicons based on their marker assignments ([`pixelator single-cell-pna demux`](https://github.com/PixelgenTechnologies/pixelator))\n3. Derive original molecules to use as edge list downstream by error correcting, and counting input amplicons ([`pixelator single-cell-pna collapse`](https://github.com/PixelgenTechnologies/pixelator))\n4. Compute the components of the graph from the edge list in order to create putative cells ([`pixelator single-cell-pna graph`](https://github.com/PixelgenTechnologies/pixelator))\n5. _(Conditional; only for PNA hashed data)_ Assign components to samples in pooled experiments ([`pixelator single-cell-pna sample-calling`](https://github.com/PixelgenTechnologies/pixelator))\n6. Denoise the cell graphs ([`pixelator single-cell-pna denoise`](https://github.com/PixelgenTechnologies/pixelator))\n7. Analyze the spatial information in the cell graphs ([`pixelator single-cell-pna analysis`](https://github.com/PixelgenTechnologies/pixelator))\n8. Generate 3D graph layouts for visualization of cells ([`pixelator single-cell-pna layout`](https://github.com/PixelgenTechnologies/pixelator))\n9. Proxiome Experiment Summary generation using [PixelatorES](https://github.com/PixelgenTechnologies/pixelatorES)\n\n> [!NOTE]\n> If you are looking to run the pipeline with Molecular Pixelation (MPX) data. Please refer to the [release 2.3.1](https://nf-co.re/pixelator/2.3.1/),\n> which is the last version to support that data type.\n\n> [!WARNING]\n> Since Nextflow 23.07.0-edge, Nextflow no longer mounts the host's home directory when using Apptainer or Singularity.\n> This causes issues in some dependencies. As a workaround, you can revert to the old behavior by setting the environment variable\n> `NXF_APPTAINER_HOME_MOUNT` or `NXF_SINGULARITY_HOME_MOUNT` to `true` in the machine from which you launch the pipeline.\n\n## Usage\n\n> [!NOTE]\n> If you are new to Nextflow and nf-core, please refer to [this page](https://nf-co.re/docs/get_started/environment_setup/overview) on how to set-up Nextflow. Make sure to [test your setup](https://nf-co.re/docs/get_started/run-your-first-pipeline) with `-profile test` before running the workflow on actual data.\n\nFirst, prepare a samplesheet with your input data that looks as follows (the exact values you need to input depend on the design and panel you are using - please see [https://nf-co.re/pixelator/usage](https://nf-co.re/pixelator/usage) for more details).\nFor hashed PNA data (Proxiome kit v2), the samplesheet will look as follows:\n\n`samplesheet.csv`:\n\n```csv\npool,hash_index,sample,sample_alias,condition,design,panel,fastq_1,fastq_2\npool1,1,sample1,s1,control,proxiome-v2,proxiome-v2-immuno-155-v2.0,pool1_R1_001.fastq.gz,pool1_R2_001.fastq.gz\npool1,2,sample2,s2,case,proxiome-v2,proxiome-v2-immuno-155-v2.0,pool1_R1_001.fastq.gz,pool1_R2_001.fastq.gz\npool2,1,sample3,s3,control,proxiome-v2,proxiome-v2-immuno-155-v2.0,pool2_R1_001.fastq.gz,pool2_R2_001.fastq.gz\n```\n\n> [!NOTE]\n> For an example with non-hashed PNA data (Proxiome kit v1), see [Proxiome v1 samplesheet](../assets/example_samplesheet_proxiome_v1.csv)\n\n> [!WARNING]\n> Panel and design names have been completely renamed in pixelator 0.26\n> (nf-core/pixelator 4.0 and above). Refer to the pixelator\n> [changelog](https://github.com/PixelgenTechnologies/pixelator/releases/tag/v0.26.0)\n> for more details.\n\nEach row represents a sample and gives the design, a panel file and the input fastq files.\n\nNow, you can run the pipeline using:\n\n```bash\nnextflow run nf-core/pixelator \\\n   -profile <docker/singularity/.../institute>,<cells_1k/cells_8k (depending on cell input)> \\\n   --technology <proxiome_v1/proxiome_v2 (depending on the kit version used)>\n   --input samplesheet.csv \\\n   --outdir <OUTDIR>\n```\n\n> [!WARNING]\n> This version of the pipeline does not support conda environments, due to issues with upstream dependencies.\n> This means you cannot use the `conda` and `mamba` profiles. Please use `docker` or `singularity` instead.\n> We hope to add support for conda environments in the future.\n\n> [!WARNING]\n> Please provide pipeline parameters via the CLI or Nextflow `-params-file` option. Custom config files including those provided by the `-c` Nextflow option can be used to provide any configuration _**except for parameters**_; see [docs](https://nf-co.re/docs/running/run-pipelines#using-parameter-files).\n\nFor more details and further functionality, please refer to the [usage documentation](https://nf-co.re/pixelator/usage) and the [parameter documentation](https://nf-co.re/pixelator/parameters).\n\n## Pipeline output\n\nTo see the results of an example test run with a full size dataset refer to the [results](https://nf-co.re/pixelator/results) tab on the nf-core website pipeline page.\nFor more details about the output files and reports, please refer to the\n[output documentation](https://nf-co.re/pixelator/output).\n\n## Credits\n\nnf-core/pixelator was originally written for [Pixelgen Technologies AB](https://www.pixelgen.com/) by:\n\n- Florian De Temmerman\n- Johan Dahlberg\n- Alvaro Martinez Barrio\n\n## Contributions and Support\n\nIf you would like to contribute to this pipeline, please see the [contributing guidelines](docs/CONTRIBUTING.md).\n\nFor further information or help, don't hesitate to get in touch on the [Slack `#pixelator` channel](https://nfcore.slack.com/channels/pixelator) (you can join with [this invite](https://nf-co.re/join/slack)).\n\n## Citations\n\nIf you use nf-core/pixelator for your analysis, please cite it using the following doi: [10.5281/zenodo.10015112](https://doi.org/10.5281/zenodo.10015112)\n\nAn extensive list of references for the tools used by the pipeline can be found in the [`CITATIONS.md`](CITATIONS.md) file.\n\nYou can cite the `nf-core` publication as follows:\n\n> **The nf-core framework for community-curated bioinformatics pipelines.**\n>\n> Philip Ewels, Alexander Peltzer, Sven Fillinger, Harshil Patel, Johannes Alneberg, Andreas Wilm, Maxime Ulysse Garcia, Paolo Di Tommaso & Sven Nahnsen.\n>\n> _Nat Biotechnol._ 2020 Feb 13. doi: [10.1038/s41587-020-0439-x](https://dx.doi.org/10.1038/s41587-020-0439-x).\n\nYou can cite the Proximity Network Technology as follows:\n\n> **Single-Cell Protein Interactomes by the Proximity Network Assay.**\n>\n> Filip Karlsson, Michele Simonetti, Christina Galonska, Max Karlsson, Hanna van Ooijen, Tomasz Kallas, Divya Thiagarajan, Maud Schweitzer, Ludvig Larsson, Vincent van Hoef, Pouria Tajvar, Johan Dahlberg, Florian De Temmerman, Louise Leijonancker, Sylvain Geny, Rikard Forlin, Erika Negrini, Stefan Petkov, Lovisa Franz\u00e9n, Jessica Bunz, Christine Moge, Henrik Everberg, Petter Brodin, Alvaro Martinez Barrio, Simon Fredriksson\n>\n> _bioRxiv_ 2025.06.19.660329; doi: [10.1101/2025.06.19.660329](https://doi.org/10.1101/2025.06.19.660329)\n",
             "hasPart": [
                 {
@@ -102,7 +102,7 @@
             },
             "mentions": [
                 {
-                    "@id": "#b08e9a66-f8b8-4587-9a7e-10048983d129"
+                    "@id": "#047d5a72-e822-45cc-8115-f31953cae2be"
                 }
             ],
             "name": "nf-core/pixelator"
@@ -129,21 +129,19 @@
                 "SoftwareSourceCode",
                 "ComputationalWorkflow"
             ],
-            "author": [
+            "creator": [
                 {
                     "@id": "https://orcid.org/0009-0006-0086-2470"
-                }
-            ],
-            "contributor": [
-                {
-                    "@id": "https://orcid.org/0000-0001-6962-1460"
                 },
                 {
-                    "@id": "https://orcid.org/0000-0001-5064-2093"
+                    "@id": "#johan.dahlberg@pixelgen.tech"
+                },
+                {
+                    "@id": "https://orcid.org/0000-0003-2702-1103"
                 }
             ],
             "dateCreated": "",
-            "dateModified": "2026-05-29T15:57:42Z",
+            "dateModified": "2026-06-04T07:56:31Z",
             "dct:conformsTo": "https://bioschemas.org/profiles/ComputationalWorkflow/1.0-RELEASE/",
             "keywords": [
                 "nf-core",
@@ -161,6 +159,9 @@
             "maintainer": [
                 {
                     "@id": "https://orcid.org/0009-0006-0086-2470"
+                },
+                {
+                    "@id": "#johan.dahlberg@pixelgen.tech"
                 }
             ],
             "name": [
@@ -174,10 +175,10 @@
             },
             "url": [
                 "https://github.com/nf-core/pixelator",
-                "https://nf-co.re/pixelator/dev/"
+                "https://nf-co.re/pixelator/4.1.2/"
             ],
             "version": [
-                "4.2.0dev"
+                "4.1.2"
             ]
         },
         {
@@ -193,11 +194,11 @@
             "version": "!>=25.10.4"
         },
         {
-            "@id": "#b08e9a66-f8b8-4587-9a7e-10048983d129",
+            "@id": "#047d5a72-e822-45cc-8115-f31953cae2be",
             "@type": "TestSuite",
             "instance": [
                 {
-                    "@id": "#1ea56774-5744-4332-bf43-225123fa4115"
+                    "@id": "#b5a6d21f-6754-4699-931f-3a07a23b0818"
                 }
             ],
             "mainEntity": {
@@ -206,7 +207,7 @@
             "name": "Test suite for nf-core/pixelator"
         },
         {
-            "@id": "#1ea56774-5744-4332-bf43-225123fa4115",
+            "@id": "#b5a6d21f-6754-4699-931f-3a07a23b0818",
             "@type": "TestInstance",
             "name": "GitHub Actions workflow for testing nf-core/pixelator",
             "resource": "repos/nf-core/pixelator/actions/workflows/nf-test.yml",
@@ -342,26 +343,20 @@
         {
             "@id": "https://orcid.org/0009-0006-0086-2470",
             "@type": "Person",
-            "affiliation": "Pixelgen Technologies AB",
             "email": "florian.detemmerman@pixelgen.com",
-            "name": "Florian De Temmerman",
-            "url": "https://github.com/fbdtemme"
+            "name": "Florian De Temmerman"
         },
         {
-            "@id": "https://orcid.org/0000-0001-6962-1460",
+            "@id": "#johan.dahlberg@pixelgen.tech",
             "@type": "Person",
-            "affiliation": "Pixelgen Technologies AB",
-            "email": "johan.dahlberg@pixelgen.com",
-            "name": "Johan Dahlberg",
-            "url": "https://github.com/johandahlberg"
+            "email": "johan.dahlberg@pixelgen.tech",
+            "name": "Johan Dahlberg"
         },
         {
-            "@id": "https://orcid.org/0000-0001-5064-2093",
+            "@id": "https://orcid.org/0000-0003-2702-1103",
             "@type": "Person",
-            "affiliation": "Pixelgen Technologies AB",
-            "email": "alvaro.martinez.barrio@pixelgen.com",
-            "name": "Alvaro Martinez Barrio",
-            "url": "https://github.com/ambarrio"
+            "email": "adrien.coulier@pixelgen.com",
+            "name": "Adrien Coulier"
         }
     ]
 }

--- a/tests/proxiome_v1.nf.test.snap
+++ b/tests/proxiome_v1.nf.test.snap
@@ -144,7 +144,7 @@
                     "pixelator": "0.28.0"
                 },
                 "Workflow": {
-                    "nf-core/pixelator": "v4.2.0dev"
+                    "nf-core/pixelator": "v4.1.2dev"
                 }
             }
         ],
@@ -192,7 +192,7 @@
                     "pixelator": "0.28.0"
                 },
                 "Workflow": {
-                    "nf-core/pixelator": "v4.2.0dev"
+                    "nf-core/pixelator": "v4.1.2dev"
                 }
             },
             [

--- a/tests/proxiome_v1.nf.test.snap
+++ b/tests/proxiome_v1.nf.test.snap
@@ -144,11 +144,11 @@
                     "pixelator": "0.28.0"
                 },
                 "Workflow": {
-                    "nf-core/pixelator": "v4.1.2dev"
+                    "nf-core/pixelator": "v4.1.2"
                 }
             }
         ],
-        "timestamp": "2026-05-27T13:33:43.278926406",
+        "timestamp": "2026-06-04T08:06:20.429989163",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.5"
@@ -192,7 +192,7 @@
                     "pixelator": "0.28.0"
                 },
                 "Workflow": {
-                    "nf-core/pixelator": "v4.1.2dev"
+                    "nf-core/pixelator": "v4.1.2"
                 }
             },
             [
@@ -301,10 +301,10 @@
                 "sample_2.meta.json:md5,82fcbb6ae5e3156c70978973c862f5f3"
             ]
         ],
-        "timestamp": "2026-05-28T09:15:28.890062884",
+        "timestamp": "2026-06-04T08:05:33.528022276",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.2"
+            "nextflow": "25.10.5"
         }
     }
 }

--- a/tests/proxiome_v1.nf.test.snap
+++ b/tests/proxiome_v1.nf.test.snap
@@ -144,7 +144,7 @@
                     "pixelator": "0.27.2"
                 },
                 "Workflow": {
-                    "nf-core/pixelator": "v4.1.1"
+                    "nf-core/pixelator": "v4.2.0dev"
                 }
             }
         ],
@@ -192,7 +192,7 @@
                     "pixelator": "0.27.2"
                 },
                 "Workflow": {
-                    "nf-core/pixelator": "v4.1.1"
+                    "nf-core/pixelator": "v4.2.0dev"
                 }
             },
             [

--- a/tests/proxiome_v1.nf.test.snap
+++ b/tests/proxiome_v1.nf.test.snap
@@ -117,31 +117,31 @@
                     "experiment-summary": "0.10.4"
                 },
                 "PIXELATOR_AMPLICON": {
-                    "pixelator": "0.27.2"
+                    "pixelator": "0.28.0"
                 },
                 "PIXELATOR_ANALYSIS": {
-                    "pixelator": "0.27.2"
+                    "pixelator": "0.28.0"
                 },
                 "PIXELATOR_COLLAPSE": {
-                    "pixelator": "0.27.2"
+                    "pixelator": "0.28.0"
                 },
                 "PIXELATOR_COMBINE_COLLAPSE": {
-                    "pixelator": "0.27.2"
+                    "pixelator": "0.28.0"
                 },
                 "PIXELATOR_DEMUX": {
-                    "pixelator": "0.27.2"
+                    "pixelator": "0.28.0"
                 },
                 "PIXELATOR_DENOISE": {
-                    "pixelator": "0.27.2"
+                    "pixelator": "0.28.0"
                 },
                 "PIXELATOR_GRAPH": {
-                    "pixelator": "0.27.2"
+                    "pixelator": "0.28.0"
                 },
                 "PIXELATOR_LAYOUT": {
-                    "pixelator": "0.27.2"
+                    "pixelator": "0.28.0"
                 },
                 "PIXELATOR_LIST_OPTIONS": {
-                    "pixelator": "0.27.2"
+                    "pixelator": "0.28.0"
                 },
                 "Workflow": {
                     "nf-core/pixelator": "v4.2.0dev"
@@ -165,31 +165,31 @@
                     "experiment-summary": "0.10.4"
                 },
                 "PIXELATOR_AMPLICON": {
-                    "pixelator": "0.27.2"
+                    "pixelator": "0.28.0"
                 },
                 "PIXELATOR_ANALYSIS": {
-                    "pixelator": "0.27.2"
+                    "pixelator": "0.28.0"
                 },
                 "PIXELATOR_COLLAPSE": {
-                    "pixelator": "0.27.2"
+                    "pixelator": "0.28.0"
                 },
                 "PIXELATOR_COMBINE_COLLAPSE": {
-                    "pixelator": "0.27.2"
+                    "pixelator": "0.28.0"
                 },
                 "PIXELATOR_DEMUX": {
-                    "pixelator": "0.27.2"
+                    "pixelator": "0.28.0"
                 },
                 "PIXELATOR_DENOISE": {
-                    "pixelator": "0.27.2"
+                    "pixelator": "0.28.0"
                 },
                 "PIXELATOR_GRAPH": {
-                    "pixelator": "0.27.2"
+                    "pixelator": "0.28.0"
                 },
                 "PIXELATOR_LAYOUT": {
-                    "pixelator": "0.27.2"
+                    "pixelator": "0.28.0"
                 },
                 "PIXELATOR_LIST_OPTIONS": {
-                    "pixelator": "0.27.2"
+                    "pixelator": "0.28.0"
                 },
                 "Workflow": {
                     "nf-core/pixelator": "v4.2.0dev"

--- a/tests/proxiome_v2.nf.test.snap
+++ b/tests/proxiome_v2.nf.test.snap
@@ -154,31 +154,31 @@
                     "experiment-summary": "0.10.4"
                 },
                 "PIXELATOR_AMPLICON": {
-                    "pixelator": "0.27.2"
+                    "pixelator": "0.28.0"
                 },
                 "PIXELATOR_ANALYSIS": {
-                    "pixelator": "0.27.2"
+                    "pixelator": "0.28.0"
                 },
                 "PIXELATOR_COLLAPSE": {
-                    "pixelator": "0.27.2"
+                    "pixelator": "0.28.0"
                 },
                 "PIXELATOR_COMBINE_COLLAPSE": {
-                    "pixelator": "0.27.2"
+                    "pixelator": "0.28.0"
                 },
                 "PIXELATOR_DEMUX": {
-                    "pixelator": "0.27.2"
+                    "pixelator": "0.28.0"
                 },
                 "PIXELATOR_DENOISE": {
-                    "pixelator": "0.27.2"
+                    "pixelator": "0.28.0"
                 },
                 "PIXELATOR_GRAPH": {
-                    "pixelator": "0.27.2"
+                    "pixelator": "0.28.0"
                 },
                 "PIXELATOR_LAYOUT": {
-                    "pixelator": "0.27.2"
+                    "pixelator": "0.28.0"
                 },
                 "PIXELATOR_LIST_OPTIONS": {
-                    "pixelator": "0.27.2"
+                    "pixelator": "0.28.0"
                 },
                 "Workflow": {
                     "nf-core/pixelator": "v4.2.0dev"
@@ -202,31 +202,31 @@
                     "experiment-summary": "0.10.4"
                 },
                 "PIXELATOR_AMPLICON": {
-                    "pixelator": "0.27.2"
+                    "pixelator": "0.28.0"
                 },
                 "PIXELATOR_ANALYSIS": {
-                    "pixelator": "0.27.2"
+                    "pixelator": "0.28.0"
                 },
                 "PIXELATOR_COLLAPSE": {
-                    "pixelator": "0.27.2"
+                    "pixelator": "0.28.0"
                 },
                 "PIXELATOR_COMBINE_COLLAPSE": {
-                    "pixelator": "0.27.2"
+                    "pixelator": "0.28.0"
                 },
                 "PIXELATOR_DEMUX": {
-                    "pixelator": "0.27.2"
+                    "pixelator": "0.28.0"
                 },
                 "PIXELATOR_DENOISE": {
-                    "pixelator": "0.27.2"
+                    "pixelator": "0.28.0"
                 },
                 "PIXELATOR_GRAPH": {
-                    "pixelator": "0.27.2"
+                    "pixelator": "0.28.0"
                 },
                 "PIXELATOR_LAYOUT": {
-                    "pixelator": "0.27.2"
+                    "pixelator": "0.28.0"
                 },
                 "PIXELATOR_LIST_OPTIONS": {
-                    "pixelator": "0.27.2"
+                    "pixelator": "0.28.0"
                 },
                 "Workflow": {
                     "nf-core/pixelator": "v4.2.0dev"

--- a/tests/proxiome_v2.nf.test.snap
+++ b/tests/proxiome_v2.nf.test.snap
@@ -181,7 +181,7 @@
                     "pixelator": "0.27.2"
                 },
                 "Workflow": {
-                    "nf-core/pixelator": "v4.1.1"
+                    "nf-core/pixelator": "v4.2.0dev"
                 }
             }
         ],
@@ -229,7 +229,7 @@
                     "pixelator": "0.27.2"
                 },
                 "Workflow": {
-                    "nf-core/pixelator": "v4.1.1"
+                    "nf-core/pixelator": "v4.2.0dev"
                 }
             },
             [

--- a/tests/proxiome_v2.nf.test.snap
+++ b/tests/proxiome_v2.nf.test.snap
@@ -181,7 +181,7 @@
                     "pixelator": "0.28.0"
                 },
                 "Workflow": {
-                    "nf-core/pixelator": "v4.2.0dev"
+                    "nf-core/pixelator": "v4.1.2dev"
                 }
             }
         ],
@@ -229,7 +229,7 @@
                     "pixelator": "0.28.0"
                 },
                 "Workflow": {
-                    "nf-core/pixelator": "v4.2.0dev"
+                    "nf-core/pixelator": "v4.1.2dev"
                 }
             },
             [

--- a/tests/proxiome_v2.nf.test.snap
+++ b/tests/proxiome_v2.nf.test.snap
@@ -181,14 +181,14 @@
                     "pixelator": "0.28.0"
                 },
                 "Workflow": {
-                    "nf-core/pixelator": "v4.1.2dev"
+                    "nf-core/pixelator": "v4.1.2"
                 }
             }
         ],
-        "timestamp": "2026-05-28T09:17:00.841226981",
+        "timestamp": "2026-06-04T08:06:34.673086328",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.2"
+            "nextflow": "25.10.5"
         }
     },
     "Params: all": {
@@ -229,7 +229,7 @@
                     "pixelator": "0.28.0"
                 },
                 "Workflow": {
-                    "nf-core/pixelator": "v4.1.2dev"
+                    "nf-core/pixelator": "v4.1.2"
                 }
             },
             [
@@ -389,10 +389,10 @@
                 "sample4.meta.json:md5,f59cd8963a4760d34bd2b41e740242b7"
             ]
         ],
-        "timestamp": "2026-05-29T14:11:36.115348351",
+        "timestamp": "2026-06-04T08:05:44.413474873",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.2"
+            "nextflow": "25.10.5"
         }
     }
 }


### PR DESCRIPTION
## [[4.1.2](https://github.com/nf-core/pixelator/releases/tag/4.1.2)] - 2026-06-04

### Enhancements & fixes

- Update pixelator container to 0.28.0. This fixes a major performance regression in the graph step, which caused very high memory usage. By @johandahlberg [#221](https://github.com/nf-core/pixelator/pull/221)

### Software dependencies

| Dependency  | Old version | New version |
| ----------- | ----------- | ----------- |
| `pixelator` | 0.27.2      | 0.28.0      |