### PR TITLE
Allocate more memory to PIXELATOR_DENOSIE for 8k_cell runs

### DIFF
--- a/conf/cells_8k.config
+++ b/conf/cells_8k.config
@@ -35,7 +35,7 @@ process {
         time   = { 20.h * task.attempt }
     }
 
-    withName: PIXELATOR_DENOSIE {
+    withName: PIXELATOR_DENOISE {
         cpus   = { 12 * task.attempt }
         memory = { 256.GB * task.attempt }
         time   = { 12.h * task.attempt }

--- a/conf/cells_8k.config
+++ b/conf/cells_8k.config
@@ -38,7 +38,7 @@ process {
     withName: PIXELATOR_DENOISE {
         cpus   = { 12 * task.attempt }
         memory = { 256.GB * task.attempt }
-        time   = { 12.h * task.attempt }
+        time   = { 16.h * task.attempt }
     }
 
     withName: EXPERIMENT_SUMMARY {

--- a/conf/cells_8k.config
+++ b/conf/cells_8k.config
@@ -35,6 +35,12 @@ process {
         time   = { 20.h * task.attempt }
     }
 
+    withName: PIXELATOR_DENOSIE {
+        cpus   = { 12 * task.attempt }
+        memory = { 256.GB * task.attempt }
+        time   = { 12.h * task.attempt }
+    }
+
     withName: EXPERIMENT_SUMMARY {
         cpus   = { 16    * task.attempt }
         memory = { 64.GB * task.attempt }


### PR DESCRIPTION
Denoise currently requires more memory to run for the 8K-cell samples. This PR increases the first iteration memory allocation from 64GB (process_high value) to 256GB.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/pixelator/tree/master/docs/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/pixelator _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
