### PR TITLE
Automate release creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,68 @@
+name: release
+# Create a git tag + published GitHub release automatically after a PR is merged into master/main.
+# Release notes are taken from the merged PR body, which for release PRs is a manual copy of the
+# latest CHANGELOG.md entry. The tag/version is read from the nextflow.config manifest.
+on:
+  pull_request:
+    types: [closed]
+    branches: [main, master]
+  workflow_dispatch:
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    if: >
+      github.repository == 'nf-core/pixelator' &&
+      (github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Check out merged code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
+          fetch-depth: 0
+
+      - name: Read version from nextflow.config
+        id: version
+        run: echo "version=$(grep -oP "^\s*version\s*=\s*'\K[0-9][^']*" nextflow.config)" >> "$GITHUB_OUTPUT"
+
+      - name: Decide whether to release
+        id: guard
+        run: |
+          V="${{ steps.version.outputs.version }}"
+          if [[ -z "$V" || "$V" == *dev ]] || git rev-parse "refs/tags/$V" >/dev/null 2>&1; then
+            echo "Skipping release (empty/dev version, or tag '$V' already exists)."
+            echo "release=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Will release version '$V'."
+            echo "release=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Assemble release notes from PR body
+        if: steps.guard.outputs.release == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.NF_CORE_BOT_AUTH_TOKEN }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          SHA: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
+        run: |
+          if [[ -n "$PR_BODY" ]]; then
+            printf '%s\n' "$PR_BODY" > release_body.md
+          else
+            gh api "repos/${GITHUB_REPOSITORY}/commits/${SHA}/pulls" --jq '.[0].body // ""' > release_body.md
+          fi
+
+      - name: Create release
+        if: steps.guard.outputs.release == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.NF_CORE_BOT_AUTH_TOKEN }}
+        run: |
+          V="${{ steps.version.outputs.version }}"
+          gh release create "$V" \
+            --target "${{ github.event.pull_request.merge_commit_sha || github.sha }}" \
+            --title "nf-core/pixelator $V" \
+            --notes-file release_body.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [[5.1.0dev]($tag_url)] - $date
 
+### Enhancements & fixed
+
+- Automate release creation. By @Aratz [#235](https://github.com/nf-core/pixelator/pull/235)
+
 ## [[5.0.0](https://github.com/nf-core/pixelator/releases/tag/5.0.0)] - 2026-07-13
 
 ### Changed

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -197,9 +197,17 @@ If you update images or graphics, follow the nf-core [style guidelines](https://
 
 ## Pipeline specific contribution guidelines
 
+### Main dependencies
+
 nf-core/pixelator is built on top of mainly
 [pixelator](https://github.com/PixelgenTechnologies/pixelator) and
 [pixelatorES](https://github.com/PixelgenTechnologies/pixelatorES), two
 products developed by Pixelgen Technologies. As open source projects, these
 also welcome contributions from everyone. Please refer to the documentation of
 these projects for more information.
+
+### Release process
+
+The release process is being partially automated. When a PR is merged to
+master, the GitHub release is created automatically from the body of the PR and
+the version defined in `nextflow.config`.


### PR DESCRIPTION
This PR adds a github workflow to automate creating the release:

Each time a PR is merged into the master branch, the workflow triggers, extract the version from `nextflow.config`, extract the release content from the PR's body and publishes that PR.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
