### PR TITLE
Automate back sync to dev after release

### DIFF
--- a/.github/workflows/post-release-sync.yml
+++ b/.github/workflows/post-release-sync.yml
@@ -1,0 +1,98 @@
+name: post-release-sync
+# After a release is published, open a PR that merges master back into dev and
+# bumps the pipeline to the next minor dev version (x.y.z -> x.(y+1).0dev).
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      released_version:
+        description: "Released version to sync back (e.g. 5.1.0). Defaults to the version on master."
+        required: false
+
+concurrency:
+  group: post-release-sync
+  cancel-in-progress: false
+
+jobs:
+  back-sync:
+    if: github.repository == 'nf-core/pixelator'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Check out dev
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: dev
+          fetch-depth: 0
+          token: ${{ secrets.NF_CORE_BOT_AUTH_TOKEN }}
+
+      - name: Compute versions
+        id: v
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+          INPUT: ${{ github.event.inputs.released_version }}
+        run: |
+          RELEASED="${TAG:-$INPUT}"
+          if [[ -z "$RELEASED" ]]; then
+            RELEASED="$(grep -oP "^\s*version\s*=\s*'\K[0-9][^']*" nextflow.config)"
+          fi
+          RELEASED="${RELEASED#v}"
+          IFS=. read -r MAJ MIN _ <<< "$RELEASED"
+          echo "released=$RELEASED" >> "$GITHUB_OUTPUT"
+          echo "next=${MAJ}.$((MIN + 1)).0dev" >> "$GITHUB_OUTPUT"
+
+      - name: Configure git and create branch
+        run: |
+          git config user.email "core@nf-co.re"
+          git config user.name "nf-core-bot"
+          git switch -c "post-release_${{ steps.v.outputs.released }}"
+          git fetch origin master
+          git merge --no-edit origin/master
+
+      - name: Install Nextflow
+        uses: nf-core/setup-nextflow@b4ec1bc7c16a94435159de94a05253542fddf6ef # v3
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.14"
+          architecture: "x64"
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+
+      - name: Read .nf-core.yml
+        uses: pietrobolcato/action-read-yaml@9f13718d61111b69f30ab4ac683e67a56d254e1d # 1.1.0
+        id: read_yml
+        with:
+          config: ${{ github.workspace }}/.nf-core.yml
+
+      - name: Install nf-core tools
+        run: uv tool install nf-core==${{ steps.read_yml.outputs['nf_core_version'] }}
+
+      - name: Bump version
+        run: nf-core pipelines bump-version "${{ steps.v.outputs.next }}"
+
+      - name: Update test snapshots
+        run: |
+          sed -i -E 's#("nf-core/pixelator": ")v[^"]*#\1v${{ steps.v.outputs.next }}#' tests/*.nf.test.snap
+
+      - name: Add CHANGELOG section
+        run: |
+          HEADER="## [[${{ steps.v.outputs.next }}](\$tag_url)] - \$date"
+          awk -v h="$HEADER" '!ins && /^## \[/ {print h; print ""; ins=1} {print}' CHANGELOG.md > CHANGELOG.tmp
+          mv CHANGELOG.tmp CHANGELOG.md
+
+      - name: Commit, push and open PR
+        env:
+          GH_TOKEN: ${{ secrets.NF_CORE_BOT_AUTH_TOKEN }}
+        run: |
+          BR="post-release_${{ steps.v.outputs.released }}"
+          git add -A
+          git commit -m "[automated] Post-release sync: bump to ${{ steps.v.outputs.next }}"
+          git push origin "$BR"
+          gh pr create --base dev --head "$BR" \
+            --title "Post-release sync: bump to ${{ steps.v.outputs.next }}" \
+            --body "Automated back-sync of master into dev after release ${{ steps.v.outputs.released }}, bumping the development version to ${{ steps.v.outputs.next }}."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Enhancements & fixed
 
 - Automate release creation. By @Aratz [#235](https://github.com/nf-core/pixelator/pull/235)
+- Automate post-release backsync to `dev`. By @Aratz [#239](https://github.com/nf-core/pixelator/pull/239)
 
 ## [[5.0.0](https://github.com/nf-core/pixelator/releases/tag/5.0.0)] - 2026-07-13
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -211,3 +211,6 @@ these projects for more information.
 The release process is being partially automated. When a PR is merged to
 master, the GitHub release is created automatically from the body of the PR and
 the version defined in `nextflow.config`.
+
+After the release has been successfully created, a new PR is automatically created
+to carry out the post-release changes on the `dev` branch.


### PR DESCRIPTION
There are a few manual steps that always need to be done after a release, namely version bumping, adding a new section to the changelog, and updating the pipeline snapshots.

This PR adds a workflow to take care of that after each release (or upon manual trigger). It pushes these changes on a new  PR to be reviewed by a pipeline maintainer.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] `CHANGELOG.md` is updated.
