### PR TITLE
Fix container override in sample calling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [[5.1.0dev]($tag_url)] - $date
 
-### Enhancements & fixed
+### Patches
 
 - Automate release creation. By @Aratz [#235](https://github.com/nf-core/pixelator/pull/235)
 - Document how to configure DuckDB temporary storage environment variables. By @johandahlberg [#238](https://github.com/nf-core/pixelator/pull/238/)
 - Automate post-release backsync to `dev`. By @Aratz [#239](https://github.com/nf-core/pixelator/pull/239)
+- Configure container override for sample calling step. By @Aratz [#241](https://github.com/nf-core/pixelator/pull/241)
 
 ### Software dependencies
 

--- a/modules/local/pixelator/sample_calling/main.nf
+++ b/modules/local/pixelator/sample_calling/main.nf
@@ -4,7 +4,7 @@ process PIXELATOR_SAMPLE_CALLING {
 
     // TODO: Add conda
     // conda "bioconda::pixelator=0.18.2"
-    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
+    container "${params.pixelator_container?:workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
         ? 'quay.io/pixelgen-technologies/pixelator:0.30.0'
         : 'quay.io/pixelgen-technologies/pixelator:0.30.0'}"
 


### PR DESCRIPTION
The `pixelator_container` parameter overrides the container in all steps except PixelatorES. This was not set up in the sample calling step. This PR addresses this issue.

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [X] Make sure your code lints (`nf-core pipelines lint`).
- [X] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [X] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] `CHANGELOG.md` is updated.
