### PR TITLE
Increase pna_graph_component_size_max_threshold default to 1M

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Document how to configure DuckDB temporary storage environment variables. By @johandahlberg [#238](https://github.com/nf-core/pixelator/pull/238/)
 - Automate post-release backsync to `dev`. By @Aratz [#239](https://github.com/nf-core/pixelator/pull/239)
 - Configure container override for sample calling step. By @Aratz [#241](https://github.com/nf-core/pixelator/pull/241)
+- Increase `pna_graph_component_size_max_threshold` default value to 1M. By @Aratz [#243](https://github.com/nf-core/pixelator/pull/243)
 
 ### Software dependencies
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -70,7 +70,7 @@ params {
     pna_graph_initial_stage_max_edges_to_remove_relative    = null
     pna_graph_refinement_stage_max_edges_to_remove_relative = null
     pna_graph_component_size_min_threshold                  = 8000
-    pna_graph_component_size_max_threshold                  = 500000
+    pna_graph_component_size_max_threshold                  = 1000000
 
     // sample-calling options
     pna_sample_calling_remove_incompatible     = true

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -292,7 +292,7 @@
                     "type": "integer",
                     "fa_icon": "fas fa-compress-alt",
                     "minimum": 1,
-                    "default": 500000,
+                    "default": 1000000,
                     "description": "Components with more nodes than this will be filtered from the output data. Set to null to enable automatic size filtering based on the data."
                 }
             }


### PR DESCRIPTION
It was noticed that some cell conjugates might exceed the previous threshold of 500k nodes and be filtered away. This PR increases this threshold to 1M nodes.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] `CHANGELOG.md` is updated.
