### PR TITLE
Fix singularity ci tests

### DIFF
--- a/.github/actions/nf-test/action.yml
+++ b/.github/actions/nf-test/action.yml
@@ -37,7 +37,7 @@ runs:
 
     - name: Setup apptainer
       if: contains(inputs.profile, 'singularity')
-      uses: eWaterCycle/setup-apptainer@4bb22c52d4f63406c49e94c804632975787312b3 # v2.0.0
+      uses: eWaterCycle/setup-apptainer@3f706d898c9db585b1d741b4692e66755f3a1b40
 
     - name: Set up Singularity
       if: contains(inputs.profile, 'singularity')

--- a/.github/workflows/nf-test.yml
+++ b/.github/workflows/nf-test.yml
@@ -77,11 +77,11 @@ jobs:
         exclude:
           - isMain: false
             profile: "conda"
-          - isMain: false
-            profile: "singularity"
+          #- isMain: false
+          #  profile: "singularity"
         NXF_VER:
           - "25.10.4"
-          - "latest-everything"
+          #- "latest-everything"
     env:
       NXF_ANSI_LOG: false
       TOTAL_SHARDS: ${{ needs.nf-test-changes.outputs.total_shards }}

--- a/.github/workflows/nf-test.yml
+++ b/.github/workflows/nf-test.yml
@@ -77,11 +77,11 @@ jobs:
         exclude:
           - isMain: false
             profile: "conda"
-          #- isMain: false
-          #  profile: "singularity"
+          - isMain: false
+            profile: "singularity"
         NXF_VER:
           - "25.10.4"
-          #- "latest-everything"
+          - "latest-everything"
     env:
       NXF_ANSI_LOG: false
       TOTAL_SHARDS: ${{ needs.nf-test-changes.outputs.total_shards }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update nf-core template to 4.0.3 by @Aratz [#236](https://github.com/nf-core/pixelator/pull/236)
 - Automate release creation. By @Aratz [#235](https://github.com/nf-core/pixelator/pull/235)
 - Automate post-release backsync to `dev`. By @Aratz [#239](https://github.com/nf-core/pixelator/pull/239)
+- Bump `setup-apptainer` back to latest version. By @Aratz [#245](https://github.com/nf-core/pixelator/pull/245)
 
 ### Software dependencies
 


### PR DESCRIPTION
For some reason, the `setup-apptainer` step in the nf-test action was bumped back to the previous version, causing the tests to fail in #244 . This PR sets it back to the latest version. This is the same setup as eg nf-core/seqinspector and sarek.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] `CHANGELOG.md` is updated.

