### PR TITLE
Restrict `all_results_for_reports` to meta.json and report.json files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Enhancements & fixes
 
 - Pass the collated software versions to the experiment summary report. By @Aratz [#248](https://github.com/nf-core/pixelator/pull/248)
+- Restrict the `all_results_for_reports` topic to `*.report.json` and `*.meta.json` so experiment summary does not stage large intermediate files. By @Aratz
 
 ## [[5.0.1](https://github.com/nf-core/pixelator/releases/tag/5.0.1)] - 2026-08-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Enhancements & fixes
 
 - Pass the collated software versions to the experiment summary report. By @Aratz [#248](https://github.com/nf-core/pixelator/pull/248)
-- Restrict the `all_results_for_reports` topic to `*.report.json` and `*.meta.json` so experiment summary does not stage large intermediate files. By @Aratz
+- Restrict the `all_results_for_reports` topic to `*.report.json` and `*.meta.json` so experiment summary does not stage large intermediate files. By @Aratz [#250](https://github.com/nf-core/pixelator/pull/250)
 
 ## [[5.0.1](https://github.com/nf-core/pixelator/releases/tag/5.0.1)] - 2026-08-17
 

--- a/modules/local/pixelator/amplicon/main.nf
+++ b/modules/local/pixelator/amplicon/main.nf
@@ -16,7 +16,7 @@ process PIXELATOR_AMPLICON {
     tuple val(meta), path("amplicon/*.report.json"),             emit: report_json
     tuple val(meta), path("amplicon/*.meta.json"),               emit: metadata_json
     tuple val(meta), path("*pixelator-amplicon.log"),            emit: log
-    tuple val('amplicon'), path("amplicon/*"),                   topic: all_results_for_reports
+    tuple val('amplicon'), path("amplicon/*.{meta,report}.json"), topic: all_results_for_reports
 
     tuple val("${task.process}"), val('pixelator'), eval("pixelator --version 2>/dev/null | sed 's/pixelator, version //g'"), emit: versions_pixelator, topic: versions
 

--- a/modules/local/pixelator/amplicon/tests/main.nf.test.snap
+++ b/modules/local/pixelator/amplicon/tests/main.nf.test.snap
@@ -50,7 +50,6 @@
                     [
                         "amplicon",
                         [
-                            "pool1.amplicon.fq.zst:md5,d41d8cd98f00b204e9800998ecf8427e",
                             "pool1.meta.json:md5,d41d8cd98f00b204e9800998ecf8427e",
                             "pool1.report.json:md5,d41d8cd98f00b204e9800998ecf8427e"
                         ]

--- a/modules/local/pixelator/analysis/main.nf
+++ b/modules/local/pixelator/analysis/main.nf
@@ -18,7 +18,7 @@ process PIXELATOR_ANALYSIS {
     tuple val(meta), path("analysis/*.meta.json"),    emit: metadata_json
     tuple val(meta), path("analysis/*"),              emit: all_results
     tuple val(meta), path("*pixelator-analysis.log"), emit: log
-    tuple val('analysis'), path("analysis/*"),        topic: all_results_for_reports
+    tuple val('analysis'), path("analysis/*.{meta,report}.json"), topic: all_results_for_reports
 
     tuple val("${task.process}"), val('pixelator'), eval("pixelator --version 2>/dev/null | sed 's/pixelator, version //g'"), emit: versions_pixelator, topic: versions
 

--- a/modules/local/pixelator/analysis/tests/main.nf.test.snap
+++ b/modules/local/pixelator/analysis/tests/main.nf.test.snap
@@ -94,7 +94,6 @@
                         "analysis",
                         [
                             "sample1.meta.json:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "sample1.pxl:md5,d41d8cd98f00b204e9800998ecf8427e",
                             "sample1.report.json:md5,d41d8cd98f00b204e9800998ecf8427e"
                         ]
                     ]

--- a/modules/local/pixelator/collapse/main.nf
+++ b/modules/local/pixelator/collapse/main.nf
@@ -18,7 +18,7 @@ process PIXELATOR_COLLAPSE {
     tuple val(meta), path("collapse/*.report.json", arity: '1..*'), emit: report_json
     tuple val(meta), path("collapse/*.meta.json"),                  emit: metadata_json
     tuple val(meta), path("*pixelator-collapse.log"),               emit: log
-    tuple val('collapse'), path("collapse/*"),                      topic: all_results_for_reports
+    tuple val('collapse'), path("collapse/*.{meta,report}.json"),    topic: all_results_for_reports
 
     tuple val("${task.process}"), val('pixelator'), eval("pixelator --version 2>/dev/null | sed 's/pixelator, version //g'"), emit: versions_pixelator, topic: versions
 

--- a/modules/local/pixelator/collapse/tests/main.nf.test.snap
+++ b/modules/local/pixelator/collapse/tests/main.nf.test.snap
@@ -83,7 +83,6 @@
                         "collapse",
                         [
                             "pool1.demux.m1.part_000.meta.json:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "pool1.demux.m1.part_000.parquet:md5,d41d8cd98f00b204e9800998ecf8427e",
                             "pool1.demux.m1.part_000.report.json:md5,d41d8cd98f00b204e9800998ecf8427e"
                         ]
                     ]

--- a/modules/local/pixelator/combine_collapse/main.nf
+++ b/modules/local/pixelator/combine_collapse/main.nf
@@ -17,7 +17,7 @@ process PIXELATOR_COMBINE_COLLAPSE {
     tuple val(meta), path("collapse/*.report.json"),          emit: report_json
     tuple val(meta), path("collapse/*.meta.json"),            emit: metadata_json
     tuple val(meta), path("*pixelator-combine-collapse.log"), emit: log
-    tuple val('collapse'), path("collapse/*"),                topic: all_results_for_reports
+    tuple val('collapse'), path("collapse/*.{meta,report}.json"), topic: all_results_for_reports
 
     tuple val("${task.process}"), val('pixelator'), eval("pixelator --version 2>/dev/null | sed 's/pixelator, version //g'"), emit: versions_pixelator, topic: versions
 

--- a/modules/local/pixelator/combine_collapse/tests/main.nf.test.snap
+++ b/modules/local/pixelator/combine_collapse/tests/main.nf.test.snap
@@ -78,7 +78,6 @@
                         "collapse",
                         [
                             "pool1.collapse.meta.json:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "pool1.collapse.parquet:md5,d41d8cd98f00b204e9800998ecf8427e",
                             "pool1.report.json:md5,d41d8cd98f00b204e9800998ecf8427e"
                         ]
                     ]

--- a/modules/local/pixelator/demux/main.nf
+++ b/modules/local/pixelator/demux/main.nf
@@ -19,7 +19,7 @@ process PIXELATOR_DEMUX {
     tuple val(meta), path("demux/*.report.json"),                 emit: report_json
     tuple val(meta), path("demux/*.meta.json"),                   emit: metadata_json
     tuple val(meta), path("*pixelator-demux.log"),                emit: log
-    tuple val('demux'), path("demux/*"),                          topic: all_results_for_reports
+    tuple val('demux'), path("demux/*.{meta,report}.json"),        topic: all_results_for_reports
 
     tuple val("${task.process}"), val('pixelator'), eval("pixelator --version 2>/dev/null | sed 's/pixelator, version //g'"), emit: versions_pixelator, topic: versions
 

--- a/modules/local/pixelator/demux/tests/main.nf.test.snap
+++ b/modules/local/pixelator/demux/tests/main.nf.test.snap
@@ -106,10 +106,6 @@
                     [
                         "demux",
                         [
-                            "pool1.demux.failed.fq.zst:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "pool1.demux.m1.part_000.parquet:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "pool1.demux.m2.part_000.parquet:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "pool1.demux.passed.fq.zst:md5,d41d8cd98f00b204e9800998ecf8427e",
                             "pool1.meta.json:md5,d41d8cd98f00b204e9800998ecf8427e",
                             "pool1.report.json:md5,d41d8cd98f00b204e9800998ecf8427e"
                         ]

--- a/modules/local/pixelator/denoise/main.nf
+++ b/modules/local/pixelator/denoise/main.nf
@@ -18,7 +18,7 @@ process PIXELATOR_DENOISE {
     tuple val(meta), path("denoise/*.meta.json")       , emit: metadata_json
     tuple val(meta), path("denoise/*")                 , emit: all_results
     tuple val(meta), path("*pixelator-denoise.log")    , emit: log
-    tuple val('denoise'), path("denoise/*")            , topic: all_results_for_reports
+    tuple val('denoise'), path("denoise/*.{meta,report}.json"), topic: all_results_for_reports
 
     tuple val("${task.process}"), val('pixelator'), eval("pixelator --version 2>/dev/null | sed 's/pixelator, version //g'"), emit: versions_pixelator, topic: versions
 

--- a/modules/local/pixelator/denoise/tests/main.nf.test.snap
+++ b/modules/local/pixelator/denoise/tests/main.nf.test.snap
@@ -93,7 +93,6 @@
                         "denoise",
                         [
                             "sample1.meta.json:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "sample1.pxl:md5,d41d8cd98f00b204e9800998ecf8427e",
                             "sample1.report.json:md5,d41d8cd98f00b204e9800998ecf8427e"
                         ]
                     ]

--- a/modules/local/pixelator/graph/main.nf
+++ b/modules/local/pixelator/graph/main.nf
@@ -16,7 +16,7 @@ process PIXELATOR_GRAPH {
     tuple val(meta), path("graph/*.report.json"),  emit: report_json
     tuple val(meta), path("graph/*.meta.json"),    emit: metadata_json
     tuple val(meta), path("*pixelator-graph.log"), emit: log
-    tuple val('graph'), path("graph/*"),           topic: all_results_for_reports
+    tuple val('graph'), path("graph/*.{meta,report}.json"), topic: all_results_for_reports
 
     tuple val("${task.process}"), val('pixelator'), eval("pixelator --version 2>/dev/null | sed 's/pixelator, version //g'"), emit: versions_pixelator, topic: versions
 

--- a/modules/local/pixelator/graph/tests/main.nf.test.snap
+++ b/modules/local/pixelator/graph/tests/main.nf.test.snap
@@ -66,7 +66,6 @@
                         "graph",
                         [
                             "pool1.meta.json:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "pool1.pxl:md5,d41d8cd98f00b204e9800998ecf8427e",
                             "pool1.report.json:md5,d41d8cd98f00b204e9800998ecf8427e"
                         ]
                     ]

--- a/modules/local/pixelator/layout/main.nf
+++ b/modules/local/pixelator/layout/main.nf
@@ -18,7 +18,7 @@ process PIXELATOR_LAYOUT {
     tuple val(meta), path("layout/*"),             emit: all_results
 
     tuple val(meta), path("*pixelator-layout.log"), emit: log
-    tuple val('layout'), path("layout/*"),          topic: all_results_for_reports
+    tuple val('layout'), path("layout/*.{meta,report}.json"), topic: all_results_for_reports
 
     tuple val("${task.process}"), val('pixelator'), eval("pixelator --version 2>/dev/null | sed 's/pixelator, version //g'"), emit: versions_pixelator, topic: versions
 

--- a/modules/local/pixelator/layout/tests/main.nf.test.snap
+++ b/modules/local/pixelator/layout/tests/main.nf.test.snap
@@ -94,7 +94,6 @@
                         "layout",
                         [
                             "sample1.meta.json:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "sample1.pxl:md5,d41d8cd98f00b204e9800998ecf8427e",
                             "sample1.report.json:md5,d41d8cd98f00b204e9800998ecf8427e"
                         ]
                     ]

--- a/modules/local/pixelator/sample_calling/main.nf
+++ b/modules/local/pixelator/sample_calling/main.nf
@@ -18,7 +18,7 @@ process PIXELATOR_SAMPLE_CALLING {
     tuple val(meta), path("sample_calling/*"),             emit: all_results
 
     tuple val(meta), path("*pixelator-sample-calling.log"), emit: log
-    tuple val('sample_calling'), path("sample_calling/*"),  topic: all_results_for_reports
+    tuple val('sample_calling'), path("sample_calling/*.{meta,report}.json"), topic: all_results_for_reports
 
     tuple val("${task.process}"), val('pixelator'), eval("pixelator --version 2>/dev/null | sed 's/pixelator, version //g'"), emit: versions_pixelator, topic: versions
 

--- a/modules/local/pixelator/sample_calling/tests/main.nf.test.snap
+++ b/modules/local/pixelator/sample_calling/tests/main.nf.test.snap
@@ -108,11 +108,7 @@
                         "sample_calling",
                         [
                             "pool1.sample_calling.meta.json:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "pool1.sample_calling.report.json:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "sample1.dehashed.pxl:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "sample2.dehashed.pxl:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "sample3.dehashed.pxl:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "sample4.dehashed.pxl:md5,d41d8cd98f00b204e9800998ecf8427e"
+                            "pool1.sample_calling.report.json:md5,d41d8cd98f00b204e9800998ecf8427e"
                         ]
                     ]
                 ],


### PR DESCRIPTION
`all_results_for_reports` gets all files generated by each step, but it only needs the json files, which are much smaller. This PR restrict what gets piped to this channel.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] `CHANGELOG.md` is updated.

